### PR TITLE
Give more info when rev not found

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -223,7 +223,7 @@ func (d Dependency) checkout() error {
 		return nil
 	}
 	if !d.vcs.exists(d.RepoPath(), d.Rev) {
-		return fmt.Errorf("unknown rev %s", d.Rev)
+		return fmt.Errorf("unknown rev %s for %s", d.Rev, d.ImportPath)
 	}
 	if err := os.MkdirAll(dir, 0777); err != nil {
 		return err


### PR DESCRIPTION
Includes the package import path when a rev cannot be found.
