### PR TITLE
dirty working tree with existing Godeps file

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -85,17 +85,16 @@ func (g *Godeps) Load(pkgs []*Package) error {
 		if pkg.Standard {
 			continue
 		}
-		vcs, reporoot, err := VCSFromDir(pkg.Dir, pkg.Root)
+		vcs, _, err := VCSFromDir(pkg.Dir, pkg.Root)
 		if err != nil {
 			log.Println(err)
 			err1 = errors.New("error loading dependencies")
 			continue
 		}
-		importPath := strings.TrimPrefix(reporoot, "src"+string(os.PathSeparator))
-		if contains(seen, importPath) {
+		if contains(seen, pkg.ImportPath) {
 			continue
 		}
-		seen = append(seen, importPath)
+		seen = append(seen, pkg.ImportPath)
 		id, err := vcs.identify(pkg.Dir)
 		if err != nil {
 			log.Println(err)


### PR DESCRIPTION
I went to try out the new save functionality on an existing repo with an existing `Godeps` file from an older `godep` release and encountered the following:

``` bash
[~/dev/src/github.com/bitly/nsq](master)$ godep save ./...
godep: dirty working tree: /Users/mreiferson/dev/src/github.com/bitly/nsq/util
godep: error loading dependencies
```

I don't have `github.com/bitly/nsq/util` as part of the exiting `Godeps` file because it's part of the repository and doesn't need to be pinned.

What's happening is that the `save` command begins by deleting any existing `Godeps` file, which is checked into vcs, thus "dirtying" the working tree when `godep` checks `isDirty` for any _local_ dependencies.  `isDirty` uses diff under the hood, so I experimented with the following patch to be more specific about what it wants diffed:

``` diff
diff --git a/vcs.go b/vcs.go
index 4ce568c..b5260ee 100644
--- a/vcs.go
+++ b/vcs.go
@@ -42,7 +42,7 @@ var vcsGit = &VCS{

        IdentifyCmd: "rev-parse HEAD",
        DescribeCmd: "describe --tags",
-       DiffCmd:     "diff {rev}",
+       DiffCmd:     "diff {rev} .",

        CreateCmd:   "init --bare",
        LinkCmd:     "remote add {remote} {url}",
```

I can open a PR taking this approach if you agree with the solution (obviously applying the fix to all the supported vcs).
