### PR TITLE
treat root packages consistently with deps

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -55,7 +55,14 @@ func (g *Godeps) Load(pkgs []*Package) error {
 			err1 = errors.New("error loading packages")
 			continue
 		}
-		seen = append(seen, p.ImportPath)
+		_, reporoot, err := VCSFromDir(p.Dir, p.Root)
+		if err != nil {
+			log.Println(err)
+			err1 = errors.New("error loading packages")
+			continue
+		}
+		importPath := strings.TrimPrefix(reporoot, "src"+string(os.PathSeparator))
+		seen = append(seen, importPath)
 		path = append(path, p.Deps...)
 	}
 	var testImports []string


### PR DESCRIPTION
This is an alternative to fix the bug reported in #22.

We avoid duplicate packages according to the repo root.
This also needs to happen for packages in the root set,
otherwise a repo with no go files in its root (for
example a package foo for which 'go list foo/...' doesn't
include foo itself) can have its internal dependencies
wrongly treated as external dependencies.
