### PR TITLE
Clarify Godep vs GOPATH in documentation

### DIFF
--- a/get.go
+++ b/get.go
@@ -10,7 +10,7 @@ var cmdGet = &Command{
 	Usage: "get [packages]",
 	Short: "download and install packages with specified dependencies",
 	Long: `
-Get downloads the packages named by the import paths, and installs
+Get downloads to GOPATH the packages named by the import paths, and installs
 them with the dependencies specified in their Godeps files.
 
 If any of the packages do not have Godeps files, those are installed

--- a/path.go
+++ b/path.go
@@ -6,13 +6,13 @@ import (
 
 var cmdPath = &Command{
 	Usage: "path",
-	Short: "print sandbox GOPATH",
+	Short: "print sandbox path for use in a GOPATH",
 	Long: `
 Path ensures a sandbox is prepared for the dependencies
-in file Godeps. It prints a GOPATH that makes available
-the specified version of each dependency.
+in file Godeps. It prints a path for use in a GOPATH
+that makes available the specified version of each dependency.
 
-The printed GOPATH does not include any GOPATH value from
+The printed path does not include any GOPATH value from
 the environment.
 
 For more about how GOPATH works, see 'go help gopath'.

--- a/restore.go
+++ b/restore.go
@@ -8,9 +8,9 @@ import (
 
 var cmdRestore = &Command{
 	Usage: "restore",
-	Short: "install package versions listed as dependencies",
+	Short: "check out listed dependency versions in GOPATH",
 	Long: `
-Restore installs the version of each package specified in Godeps.
+Restore checks out the Godeps-specified version of each package in GOPATH.
 `,
 	Run: runRestore,
 }

--- a/save.go
+++ b/save.go
@@ -14,13 +14,13 @@ import (
 
 var cmdSave = &Command{
 	Usage: "save [-copy=false] [packages]",
-	Short: "list current dependencies to a file",
+	Short: "list and copy dependencies into Godeps",
 	Long: `
 Save writes a list of the dependencies of the named packages along
 with the exact source control revision of each dependency, and copies
 their source code into a subdirectory.
 
-Output is a JSON document with the following structure:
+The dependency list is a JSON document with the following structure:
 
 	type Godeps struct {
 		ImportPath string


### PR DESCRIPTION
The immediate impetus for these changes was that
the `restore` command had unclear help text.
Clarifying it required some matching changes
elsewhere.

Note that the verb "check out" in `restore`'s
Long usage text is also used in a similar context
in `go help get`:

"When checking out or updating a package, get
looks for a branch or tag that matches the locally
installed version of Go."

Fixes #33.
