### PR TITLE
Add simple version command

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ var commands = []*Command{
 	cmdGet,
 	cmdPath,
 	cmdRestore,
+	cmdVersion,
 }
 
 func main() {

--- a/version.go
+++ b/version.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+)
+
+const (
+	Version = "dev"
+)
+
+var cmdVersion = &Command{
+	Run:   runVersion,
+	Usage: "version",
+	Short: "Display current version",
+	Long: `
+Display current version
+
+Examples:
+
+  godep version
+`,
+}
+
+func init() {
+}
+
+func runVersion(cmd *Command, args []string) {
+	fmt.Println("godep version:", Version)
+}


### PR DESCRIPTION
This adds a very simple version command.
Usage:

```console
$ godep version
godep version: dev
```