### PR TITLE
Add a -extonly option to "godep save"

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -57,22 +57,25 @@ func (g *Godeps) Load(pkgs []*Package, extonly bool) error {
 			continue
 		}
 
-		// If we were called without a package name, p.Root will be
-		// unset, but we can use the current dir as the root
-		if p.Root == "" {
-			pwd, err := os.Getwd()
-			if err != nil {
-				log.Println(err)
+		if extonly {
+			// Keep track of all the "homes" of the specified
+			// packages. The home is the Root if set, or the p.Dir if
+			// the root cannot be determined (normally when saving
+			// "main" for a golang project that doesn't follow the
+			// directory naming conventions)
+			if p.Root != "" {
+				home = append(home, p.Root)
+			} else {
+				home = append(home, p.Dir)
+			}
+		} else {
+			if p.Root == "" {
+				log.Printf("Root dir cannot be determined for packages in %s.", p.Dir)
+				log.Println("  If these are all under your control, you could try running with -extonly.")
 				err1 = errors.New("error loading packages")
 				continue
 			}
-			p.Root = pwd
-		}
 
-		if extonly {
-			// Keep track of all the "homes" of the specified packages
-			home = append(home, p.Root)
-		} else {
 			_, reporoot, err := VCSFromDir(p.Dir, p.Root)
 			if err != nil {
 				log.Println(err)

--- a/save.go
+++ b/save.go
@@ -13,7 +13,7 @@ import (
 )
 
 var cmdSave = &Command{
-	Usage: "save [-copy=false] [packages]",
+	Usage: "save [-copy=false] [-extonly] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 Save writes a list of the dependencies of the named packages along
@@ -35,6 +35,10 @@ The dependency list is a JSON document with the following structure:
 
 If -copy=false is given, the list alone is written to file Godeps.
 
+If -extonly is given, only packages external to the current source
+tree are counted. This is useful if your source tree doesn't conform
+to go packaging guidelines, but its dependencies do.
+
 Otherwise, the list is written to Godeps/Godeps.json, and source
 code for all dependencies is copied into Godeps/_workspace.
 
@@ -44,9 +48,11 @@ For more about specifying packages, see 'go help packages'.
 }
 
 var flagCopy = true
+var flagExtonly = false
 
 func init() {
 	cmdSave.Flag.BoolVar(&flagCopy, "copy", true, "copy source code")
+	cmdSave.Flag.BoolVar(&flagExtonly, "extonly", false, "external packages only")
 }
 
 func runSave(cmd *Command, args []string) {
@@ -65,7 +71,7 @@ func runSave(cmd *Command, args []string) {
 		args = []string{"."}
 	}
 	a := MustLoadPackages(args...)
-	err := g.Load(a)
+	err := g.Load(a, flagExtonly)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
I have a project that includes Go components alongside other components, all organized together in the same repo.

By necessity, this project doesn't follow the directory naming conventions for Go packages, but its dependencies do.

My project's structure is:

```
/opt/myproj/src/packagename/packagename.go
/opt/myproj/python/...
```

where `/opt/myproj` is the root of the repository.

I'd like to be able to use godep for this, but unfortunately it makes a few assumptions that are incompatible with my project. The two assumptions that don't hold true for my project are:

1. `go list -e -json` always returns a "Root" parameter. It does not for my project when pwd = `/opt/myproj/src`
2. `p.Dir` and `p.Root` are never the same directory. If they are, you get this error:

```
godep: directory "/opt/myproj" is not using a known version control system
```

which looks to be an artifact of the [implementation of FromDir in vcs.go](https://code.google.com/p/go/source/browse/go/vcs/vcs.go?repo=tools#347).

I've added a "-extonly" option which resolves this for me, and thought you might be interested in taking it upstream.

It keeps track of the "homes" of the requested packages (their `p.Root` or `p.Dir` if there is no `p.Root`) and excludes packages found in that "home" from the dependency list.

I appreciate this is all pretty new to me and you may have a better solution to this problem. But here's a work-in-progress in case it provides some part of the overall solution to this problem.