### PR TITLE
include XTestImports when godep saving

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -66,10 +66,13 @@ func (g *Godeps) Load(pkgs []*Package) error {
 		seen = append(seen, importPath+"/")
 		path = append(path, p.Deps...)
 	}
+
 	var testImports []string
 	for _, p := range pkgs {
 		testImports = append(testImports, p.TestImports...)
+		testImports = append(testImports, p.XTestImports...)
 	}
+
 	for _, p := range MustLoadPackages(testImports...) {
 		if p.Standard {
 			continue
@@ -82,6 +85,7 @@ func (g *Godeps) Load(pkgs []*Package) error {
 		path = append(path, p.ImportPath)
 		path = append(path, p.Deps...)
 	}
+
 	sort.Strings(path)
 	path = uniq(path)
 	for _, pkg := range MustLoadPackages(path...) {

--- a/pkg.go
+++ b/pkg.go
@@ -15,7 +15,8 @@ type Package struct {
 	Deps       []string
 	Standard   bool
 
-	TestImports []string
+	TestImports  []string
+	XTestImports []string
 
 	Error struct {
 		Err string


### PR DESCRIPTION
This changes 'godep save' to include XTestImports as well as TestImports. For our tests we always have them in a separate package named '(packagename)_test', which keeps them living beside the code but has them namespaced away so we can't dig into the unexported bits. So without this change godep does not grab our test dependencies.

I'm not sure if there are any cases where Godep shouldn't bring in XTestImports. In the Go documentation it says "_test.go files outside package", which I think exactly describes our use case and nothing else?
