### PR TITLE
test the save function in process

### DIFF
--- a/get.go
+++ b/get.go
@@ -33,7 +33,11 @@ func runGet(cmd *Command, args []string) {
 
 	// group import paths by Godeps location
 	groups := make(map[string][]string)
-	for _, pkg := range MustLoadPackages(args...) {
+	ps, err := LoadPackages(args...)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	for _, pkg := range ps {
 		if pkg.Error.Err != "" {
 			log.Fatalln(pkg.Error.Err)
 		}

--- a/pkg.go
+++ b/pkg.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 )
@@ -21,16 +20,6 @@ type Package struct {
 	Error struct {
 		Err string
 	}
-}
-
-// MustLoadPackages is like LoadPackages but it calls log.Fatal
-// if an error occurs.
-func MustLoadPackages(name ...string) []*Package {
-	p, err := LoadPackages(name...)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return p
 }
 
 // LoadPackages loads the named packages using go list -json.

--- a/restore.go
+++ b/restore.go
@@ -41,7 +41,11 @@ func restore(dep Dependency) error {
 	if err != nil {
 		return err
 	}
-	pkg := MustLoadPackages(dep.ImportPath)[0]
+	ps, err := LoadPackages(dep.ImportPath)
+	if err != nil {
+		return err
+	}
+	pkg := ps[0]
 	if !dep.vcs.exists(pkg.Dir, dep.Rev) {
 		dep.vcs.vcs.Download(pkg.Dir)
 	}

--- a/save_test.go
+++ b/save_test.go
@@ -202,17 +202,29 @@ func TestSave(t *testing.T) {
 		}
 		src := filepath.Join(gopath, "src")
 		makeTree(t, &node{src, "", test.start})
-		cmd := exec.Command("godep", "save")
-		cmd.Dir = filepath.Join(src, test.cwd)
-		cmd.Env = append(envNoGopath(), "GOPATH="+filepath.Join(wd, gopath))
-		out, err := cmd.CombinedOutput()
+
+		dir := filepath.Join(wd, src, test.cwd)
+		err = os.Chdir(dir)
 		if err != nil {
-			t.Log(string(out))
-			t.Fatal(err)
+			panic(err)
 		}
+		err = os.Setenv("GOPATH", filepath.Join(wd, gopath))
+		if err != nil {
+			panic(err)
+		}
+		err = save(nil)
+		if err != nil {
+			t.Error("save:", err)
+			continue
+		}
+		err = os.Chdir(wd)
+		if err != nil {
+			panic(err)
+		}
+
 		checkTree(t, &node{src, "", test.want})
 
-		f, err := os.Open(filepath.Join(cmd.Dir, "Godeps/Godeps.json"))
+		f, err := os.Open(filepath.Join(dir, "Godeps/Godeps.json"))
 		if err != nil {
 			t.Error(err)
 		}


### PR DESCRIPTION
Two benefits:
1. We are guaranteed to be testing the correct logic.
   Without this change, the test would pick up whatever
   'godep' command is in the path, which isn't necessarily
   the same as the code in this directory.
2. Code coverage is now measured.
