### PR TITLE
create a symlink for the repo itself during save

### DIFF
--- a/save.go
+++ b/save.go
@@ -133,6 +133,17 @@ func save(pkgs []string) error {
 		//   godep go list ./...
 		workspace := filepath.Join("Godeps", "_workspace")
 		srcdir := filepath.Join(workspace, "src")
+
+		srcimport := filepath.Join(srcdir, gnew.ImportPath)
+		err = os.RemoveAll(srcimport)
+		if err != nil {
+			return err
+		}
+		err = relSymlink("./", srcimport)
+		if err != nil {
+			return err
+		}
+
 		rem := subDeps(gold.Deps, gnew.Deps)
 		add := subDeps(gnew.Deps, gold.Deps)
 		err = removeSrc(srcdir, rem)
@@ -343,6 +354,17 @@ func writeFile(name, body string) error {
 		return err
 	}
 	return ioutil.WriteFile(name, []byte(body), 0666)
+}
+
+// relSymlink creates a relative symlink to orig placing it at dest.
+func relSymlink(orig string, dest string) error {
+	destparent := filepath.Dir(dest)
+	os.MkdirAll(destparent, 0777)
+	rel, err := filepath.Rel(destparent, orig)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(rel, dest)
 }
 
 const Readme = `


### PR DESCRIPTION
This change is to create a symlink to the top of the repo at the proper location within `Godeps/_workspace/src`.
This is so that you can build a go project without it being in a proper `GOPATH` location.

Lets say you have a project `github.com/acmeco/rocket`, which has go files with `import`s such as `github.com/acmeco/rocket/engine`. When `go build` tries to build them, it's going to look for `rocket/engine` in the `GOPATH` locations. If the repo is not in such a location, it will fail.

This has several potential uses. The 2 reasons we need this change are:
1. When using jenkins to build from a repo, jenkins checks the source out to predefined location which cannot be controlled.
2. When building a repo within a docker container, it alleviates the need for having to figure out the path structure of where the repo should be placed within the container.

&nbsp;

So with this change, you would have a symlink at `Godeps/_workspace/src/github.com/acmeco/rocket` which points to `../../../../../` (the top of the repo).
