### PR TITLE
allow godep save without complaining when bzr is used

### DIFF
--- a/save.go
+++ b/save.go
@@ -102,11 +102,6 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	if a := badSandboxVCS(gnew.Deps); a != nil && !saveCopy {
-		log.Println("Unsupported sandbox VCS:", strings.Join(a, ", "))
-		log.Printf("Instead, run: godep save -copy %s", strings.Join(pkgs, " "))
-		return errors.New("error")
-	}
 	if gnew.Deps == nil {
 		gnew.Deps = make([]Dependency, 0) // produce json [], not null
 	}


### PR DESCRIPTION
This error seems spurious, and means it's not possible to do:

    godep save -copy=false
    godep restore

if the project has a bzr dependency.

This may well be an insufficient fix - something else may also
required, but hopefully this should get the ball rolling.