### PR TITLE
Updates Readme.md for clarity

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,20 +32,31 @@ subsequent invocations of `godep go` will need to access the
 network to fetch the appropriate source code later. Using the
 default behavior is faster and more reliable.
 
+#### Restore
+
+The `godep restore` command is the opposite of `godep save`. It will copy the package
+versions specified in Godeps/Godeps.json to your $GOPATH 
+
 #### Edit-test Cycle
 
 1. Edit code
 2. Run `godep go test`
 3. (repeat)
 
-#### Add or Update a Dependency
+#### Add a Dependency
 
-To add or update package foo/bar, do this:
+To add a new package foo/bar, do this:
 
-1. Run `godep restore`
-2. Run `go get -u foo/bar`
-3. Edit your code, if necessary, to import foo/bar.
-4. Run `godep save`
+1. Run `go get foo/bar`
+2. Edit your code, if necessary, to import foo/bar.
+3. Run `godep save` or `godep save ./...` to scan the entire project structure.
+
+#### Update a Dependency
+
+To update a package from your `$GOPATH`, do this:
+
+1. Run `go get -u foo/bar`
+2. Run `godep update foo/bar` or with the `...` wildcard as `godep update foo/...`
 
 Before committing the change, you'll probably want to inspect
 the changes to Godeps, for example with `git diff`,


### PR DESCRIPTION
I'm new Godep and it took me a while to understand that `godep restore` is basically the opposite of `godep save` and was slightly alarmed that it would overwrite files in my $GOPATH. The source of my confusion was the Add/Update section of the readme which has restore as the first step. Furthermore, that section does not actually work for updating a package. Looks like the update command was added recently for this specific purpose, so I broke out the two sections to have their own explanation.
