### PR TITLE
Pass --force when checking out git repos

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -49,7 +49,7 @@ var vcsGit = &VCS{
 	LinkCmd:     "remote add {remote} {url}",
 	ExistsCmd:   "cat-file -e {rev}",
 	FetchCmd:    "fetch --quiet {remote}",
-	CheckoutCmd: "--git-dir {repo} --work-tree . checkout -q {rev}",
+	CheckoutCmd: "--git-dir {repo} --work-tree . checkout -q --force {rev}",
 }
 
 var vcsHg = &VCS{


### PR DESCRIPTION
When a bare git repo has already been checked out and it is checked out again into a different directory, only files changed between HEAD and the new commit will appear in the new directory. The rest of the files will be treated as unstaged deletions.

Passing --force changes this to discard local changes (i.e. the perceived deletion of files) and checks out all the files.
