### PR TITLE
When an external command fails, say what the command was in the error

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -315,11 +314,10 @@ func uniq(a []string) []string {
 func goVersion() (string, error) {
 	// Godep might have been compiled with a different
 	// version, so we can't just use runtime.Version here.
-	cmd := exec.Command("go", "version")
-	cmd.Stderr = os.Stderr
-	out, err := cmd.Output()
+	c := command("go", "version")
+	out, err := c.Output()
 	if err != nil {
-		return "", err
+		return "", errorWithCommand(err, c)
 	}
 	s := strings.TrimSpace(string(out))
 	s = strings.TrimSuffix(s, " "+runtime.GOOS+"/"+runtime.GOARCH)

--- a/get.go
+++ b/get.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"os"
 	"os/exec"
 )
 
@@ -26,9 +25,10 @@ func runGet(cmd *Command, args []string) {
 		args = []string{"."}
 	}
 
-	err := command("go", "get", "-d", args).Run()
+	goget := command("go", "get", "-d", args)
+	err := goget.Run()
 	if err != nil {
-		log.Fatalln(err)
+		log.Fatalln(errorWithCommand(err, goget))
 	}
 
 	// group import paths by Godeps location
@@ -53,25 +53,7 @@ func runGet(cmd *Command, args []string) {
 			c.Dir = dir
 		}
 		if err := c.Run(); err != nil {
-			log.Fatalln(err)
+			log.Fatalln(errorWithCommand(err, c))
 		}
 	}
-}
-
-// command is like exec.Command, but the returned
-// Cmd inherits stderr from the current process, and
-// elements of args may be either string or []string.
-func command(name string, args ...interface{}) *exec.Cmd {
-	var a []string
-	for _, arg := range args {
-		switch v := arg.(type) {
-		case string:
-			a = append(a, v)
-		case []string:
-			a = append(a, v...)
-		}
-	}
-	c := exec.Command(name, a...)
-	c.Stderr = os.Stderr
-	return c
 }

--- a/go.go
+++ b/go.go
@@ -48,7 +48,7 @@ func runGo(cmd *Command, args []string) {
 	c.Stderr = os.Stderr
 	err := c.Run()
 	if err != nil {
-		log.Fatalln("go", err)
+		log.Fatalln("go", errorWithCommand(err, c))
 	}
 }
 

--- a/pkg.go
+++ b/pkg.go
@@ -36,15 +36,15 @@ func LoadPackages(name ...string) (a []*Package, err error) {
 		return nil, nil
 	}
 	args := []string{"list", "-e", "-json"}
-	cmd := exec.Command("go", append(args, name...)...)
-	r, err := cmd.StdoutPipe()
+	c := exec.Command("go", append(args, name...)...)
+	r, err := c.StdoutPipe()
 	if err != nil {
-		return nil, err
+		return nil, errorWithCommand(err, c)
 	}
-	cmd.Stderr = os.Stderr
-	err = cmd.Start()
+	c.Stderr = os.Stderr
+	err = c.Start()
 	if err != nil {
-		return nil, err
+		return nil, errorWithCommand(err, c)
 	}
 	d := json.NewDecoder(r)
 	for {
@@ -58,9 +58,9 @@ func LoadPackages(name ...string) (a []*Package, err error) {
 		}
 		a = append(a, info)
 	}
-	err = cmd.Wait()
+	err = c.Wait()
 	if err != nil {
-		return nil, err
+		return nil, errorWithCommand(err, c)
 	}
 	return a, nil
 }

--- a/util.go
+++ b/util.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // Returns true if path definitely exists; false if path doesn't
@@ -21,5 +23,31 @@ func runIn(dir, name string, args ...string) error {
 	c.Dir = dir
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	return c.Run()
+	err := c.Run()
+	return errorWithCommand(err, c)
+}
+
+// command is like exec.Command, but the returned
+// Cmd inherits stderr from the current process, and
+// elements of args may be either string or []string.
+func command(name string, args ...interface{}) *exec.Cmd {
+	var a []string
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case string:
+			a = append(a, v)
+		case []string:
+			a = append(a, v...)
+		}
+	}
+	c := exec.Command(name, a...)
+	c.Stderr = os.Stderr
+	return c
+}
+
+func errorWithCommand(err error, cmd *exec.Cmd) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("Error running `%s`: %s", strings.Join(cmd.Args, " "), err.Error())
 }

--- a/vcs.go
+++ b/vcs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -201,7 +202,7 @@ func (v *VCS) run1(dir string, cmdline string, kv []string, verbose bool) ([]byt
 			fmt.Fprintf(os.Stderr, "# cd %s; %s %s\n", dir, v.vcs.Cmd, strings.Join(args, " "))
 			os.Stderr.Write(out)
 		}
-		return nil, err
+		return nil, errorWithCommand(err, cmd)
 	}
 	return out, nil
 }


### PR DESCRIPTION
This changes all the spots where external commands are run to include the command that was run in the error string.

I was working on this as part of diagnosing #71

It turns out that the problem in #71 isn't related to running external commands from godep code, but I figured this might be nice to have anyway.
