### PR TITLE
don't require listed packages to be in VCS

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -62,13 +62,16 @@ func (g *Godeps) Load(pkgs []*Package) error {
 			err1 = errors.New("error loading packages")
 			continue
 		}
+		// If we can find the root of a VCS repo, then
+		// mark the entire repo as seen, not just p.
+		// This avoids unnecessarily copying other packages
+		// in the same repo but outside of p's subtree.
 		_, reporoot, err := VCSFromDir(p.Dir, filepath.Join(p.Root, "src"))
-		if err != nil {
-			log.Println(err)
-			err1 = errors.New("error loading packages")
-			continue
+		if err == nil {
+			seen = append(seen, filepath.ToSlash(reporoot))
+		} else {
+			seen = append(seen, p.ImportPath)
 		}
-		seen = append(seen, filepath.ToSlash(reporoot))
 		path = append(path, p.Deps...)
 	}
 	var testImports []string


### PR DESCRIPTION
To avoid copying dependencies unnecessarily, we try to
find the root of the VCS repo for each package in the
root set, and mark the import path of the entire repo as
"seen". This means for a repo at path C, if package C/S
imports C/T, we do not want to copy C/T into C/S/Godeps.
This behavior was already present, but now we have a
test for it.

However, some packages aren't in a repo at all, or the
root of the repo is outside the GOPATH src tree. In that
case, we just mark the import path of that package
itself as "seen".