### PR TITLE
include command line packages in the set to copy

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -12,8 +12,8 @@ var cmdDiff = &Command{
 	Usage: "diff",
 	Short: "shows the diff between current and previously saved set of dependencies",
 	Long: `
-Shows the difference, in a unified diff format, between the 
-current set of dependencies and those generated on a 
+Shows the difference, in a unified diff format, between the
+current set of dependencies and those generated on a
 previous 'go save' execution.
 `,
 	Run: runDiff,
@@ -43,7 +43,7 @@ func runDiff(cmd *Command, args []string) {
 		GoVersion:  ver,
 	}
 
-	err = gnew.Load(dot)
+	err = gnew.Load(dot, dot[0].ImportPath)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/save.go
+++ b/save.go
@@ -20,9 +20,11 @@ var cmdSave = &Command{
 	Usage: "save [-r] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
-Save writes a list of the dependencies of the named packages along
-with the exact source control revision of each dependency, and copies
-their source code into a subdirectory.
+
+Save writes a list of the named packages and their dependencies along
+with the exact source control revision of each package, and copies
+their source code into a subdirectory. Packages inside . are excluded
+from the list to be copied.
 
 The list is written to Godeps/Godeps.json, and source code for all
 dependencies is copied into either Godeps/_workspace or, if the vendor
@@ -41,7 +43,7 @@ The dependency list is a JSON document with the following structure:
 		}
 	}
 
-Any dependencies already present in the list will be left unchanged.
+Any packages already present in the list will be left unchanged.
 To update a dependency to a newer revision, use 'godep update'.
 
 If -r is given, import statements will be rewritten to refer
@@ -106,7 +108,7 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	err = gnew.Load(a)
+	err = gnew.Load(a, dot[0].ImportPath)
 	if err != nil {
 		return err
 	}

--- a/save_test.go
+++ b/save_test.go
@@ -923,6 +923,58 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // don't require packages contained in dest to be in VCS
+			cwd:   "C",
+			flagR: true,
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main"), nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps:       []Dependency{},
+			},
+		},
+		{ // include command line packages in the set to be copied
+			cwd:   "C",
+			args:  []string{"P"},
+			flagR: true,
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main"), nil},
+					},
+				},
+				{
+					"P",
+					"",
+					[]*node{
+						{"main.go", pkg("P"), nil},
+						{"+git", "P1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main"), nil},
+				{"C/Godeps/_workspace/src/P/main.go", pkg("P"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "P", Comment: "P1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = 1
+const version = 2


### PR DESCRIPTION
This is a simplification to how we define the behavior
of the save command. Now it has two distinct package
parameters, the "root set" and the "destination", and
they have clearer roles. The packages listed on the
command line form the root set; they and all their
dependencies will be copied into the Godeps directory.
Additionally, the destination (always ".") will form the
initial list of "seen" import paths to exclude from
copying.

In the common case, the root set is equal to the
destination, so the effective behavior doesn't change.
This is primarily just a simpler definition. However, if
the user specifies a package on the command line that
lives outside of . then that package will be copied.

As a side effect, there's a simplification to the way we
add packages to the initial "seen" set. Formerly, to
avoid copying dependencies unnecessarily, we would try
to find the root of the VCS repo for each package in the
root set, and mark the import path of the entire repo as
seen. This meant for a repo at path C, if destination
C/S imports C/T, we would not copy C/T into C/S/Godeps.
Now we don't treat the repo root specially, and as
mentioned above, the destination alone is considered
seen.

This also means we don't require listed packages to be
in VCS unless they're outside of the destination.