### PR TITLE
Added support for build tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,8 +59,11 @@ var commands = []*Command{
 	cmdUpdate,
 }
 
+var buildTags = ""
+
 func main() {
 	flag.Usage = usageExit
+	flag.StringVar(&buildTags, "tags", "", "build tags to use")
 	flag.Parse()
 	log.SetFlags(0)
 	log.SetPrefix("godep: ")
@@ -93,7 +96,7 @@ Godep is a tool for managing Go package dependencies.
 
 Usage:
 
-	godep command [arguments]
+	godep [-tags buildtags] command [arguments]
 
 The commands are:
 {{range .}}

--- a/pkg.go
+++ b/pkg.go
@@ -36,6 +36,9 @@ func LoadPackages(name ...string) (a []*Package, err error) {
 		return nil, nil
 	}
 	args := []string{"list", "-e", "-json"}
+	if buildTags != "" {
+		args = append(args, "-tags", buildTags)
+	}
 	cmd := exec.Command("go", append(args, name...)...)
 	r, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Attempt to fix https://github.com/tools/godep/issues/84 , adds build tags support to all commands.