### PR TITLE
feature: add a verbose flag to 'save' operation

### DIFF
--- a/rewrite.go
+++ b/rewrite.go
@@ -77,7 +77,7 @@ func rewriteGoFile(name, qual string, paths []string) error {
 		}
 		q := qualify(unqualify(importName), qual, paths)
 		if q != importName {
-			printVerbose("rewrite "+name, s.Path.Value, "→", q)
+			vprintln("rewrite "+name, s.Path.Value, "->", q)
 			s.Path.Value = strconv.Quote(q)
 			changed = true
 		}

--- a/rewrite.go
+++ b/rewrite.go
@@ -71,12 +71,13 @@ func rewriteGoFile(name, qual string, paths []string) error {
 
 	var changed bool
 	for _, s := range f.Imports {
-		name, err := strconv.Unquote(s.Path.Value)
+		importName, err := strconv.Unquote(s.Path.Value)
 		if err != nil {
 			return err // can't happen
 		}
-		q := qualify(unqualify(name), qual, paths)
-		if q != name {
+		q := qualify(unqualify(importName), qual, paths)
+		if q != importName {
+			printVerbose("rewrite "+name, s.Path.Value, "→", q)
 			s.Path.Value = strconv.Quote(q)
 			changed = true
 		}

--- a/save.go
+++ b/save.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -17,7 +18,7 @@ import (
 )
 
 var cmdSave = &Command{
-	Usage: "save [-r] [packages]",
+	Usage: "save [-r] [-v] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 Save writes a list of the dependencies of the named packages along
@@ -48,19 +49,23 @@ If -r is given, import statements will be rewritten to refer
 directly to the copied source code. This is not compatible with the
 vendor experiment.
 
+If -v is given, the verbosity will be increased
+
 For more about specifying packages, see 'go help packages'.
 `,
 	Run: runSave,
 }
 
 var (
-	saveCopy = true
-	saveR    = false
+	saveCopy    = true
+	saveR       = false
+	saveVerbose = true
 )
 
 func init() {
 	cmdSave.Flag.BoolVar(&saveCopy, "copy", true, "copy source code")
 	cmdSave.Flag.BoolVar(&saveR, "r", false, "rewrite import paths")
+	cmdSave.Flag.BoolVar(&saveVerbose, "v", false, "verbose")
 }
 
 func runSave(cmd *Command, args []string) {
@@ -97,6 +102,10 @@ func save(pkgs []string) error {
 		ImportPath: dot[0].ImportPath,
 		GoVersion:  ver,
 	}
+
+	printVerbose("import-path", gnew.ImportPath)
+	printVerbose("go-version", gnew.GoVersion)
+
 	if len(pkgs) > 0 {
 		gnew.Packages = pkgs
 	} else {
@@ -221,6 +230,7 @@ func carryVersion(a *Godeps, db *Dependency) error {
 	// First see if this exact package is already in the list.
 	for _, da := range a.Deps {
 		if db.ImportPath == da.ImportPath {
+			printVerbose("dependency", db.ImportPath, db.Rev, db.Comment)
 			db.Rev = da.Rev
 			db.Comment = da.Comment
 			return nil
@@ -242,6 +252,7 @@ func carryVersion(a *Godeps, db *Dependency) error {
 		}
 	}
 	// No related package in the list, must be a new repo.
+	printVerbose("new dependency", db.ImportPath, db.Rev, db.Comment)
 	return nil
 }
 
@@ -279,6 +290,7 @@ func copySrc(dir string, deps []Dependency) error {
 			return err
 		}
 		dstpkgroot := filepath.Join(dir, rel)
+		printVerbose("copy", dep.dir, "→", dstpkgroot)
 		err = os.RemoveAll(dstpkgroot)
 		if err != nil {
 			log.Println(err)
@@ -435,6 +447,13 @@ func writeFile(name, body string) error {
 		return err
 	}
 	return ioutil.WriteFile(name, []byte(body), 0666)
+}
+
+func printVerbose(args ...interface{}) {
+	if saveVerbose {
+		args[0] = "\033[1m" + fmt.Sprintf("%s", args[0]) + "\033[0m:\t"
+		fmt.Println(args...)
+	}
 }
 
 const (

--- a/save.go
+++ b/save.go
@@ -103,8 +103,8 @@ func save(pkgs []string) error {
 		GoVersion:  ver,
 	}
 
-	printVerbose("import-path", gnew.ImportPath)
-	printVerbose("go-version", gnew.GoVersion)
+	vprintln("import-path", gnew.ImportPath)
+	vprintln("go-version", gnew.GoVersion)
 
 	if len(pkgs) > 0 {
 		gnew.Packages = pkgs
@@ -230,7 +230,7 @@ func carryVersion(a *Godeps, db *Dependency) error {
 	// First see if this exact package is already in the list.
 	for _, da := range a.Deps {
 		if db.ImportPath == da.ImportPath {
-			printVerbose("dependency", db.ImportPath, db.Rev, db.Comment)
+			vprintln("dependency", db.ImportPath, db.Rev, db.Comment)
 			db.Rev = da.Rev
 			db.Comment = da.Comment
 			return nil
@@ -252,7 +252,7 @@ func carryVersion(a *Godeps, db *Dependency) error {
 		}
 	}
 	// No related package in the list, must be a new repo.
-	printVerbose("new dependency", db.ImportPath, db.Rev, db.Comment)
+	vprintln("new dependency", db.ImportPath, db.Rev, db.Comment)
 	return nil
 }
 
@@ -290,7 +290,7 @@ func copySrc(dir string, deps []Dependency) error {
 			return err
 		}
 		dstpkgroot := filepath.Join(dir, rel)
-		printVerbose("copy", dep.dir, "→", dstpkgroot)
+		vprintln("copy", dep.dir, "->", dstpkgroot)
 		err = os.RemoveAll(dstpkgroot)
 		if err != nil {
 			log.Println(err)
@@ -449,9 +449,9 @@ func writeFile(name, body string) error {
 	return ioutil.WriteFile(name, []byte(body), 0666)
 }
 
-func printVerbose(args ...interface{}) {
+func vprintln(args ...interface{}) {
 	if saveVerbose {
-		args[0] = "\033[1m" + fmt.Sprintf("%s", args[0]) + "\033[0m:\t"
+		args[0] = fmt.Sprintf("%s", args[0]) + ":\t"
 		fmt.Println(args...)
 	}
 }


### PR DESCRIPTION
I've developed that to have an overview of what was happening
when running godep, it's still a bit drafty.

Sample output:

```
$ godep save -r -v
import-path:	 github.com/Soulou/sample-project
go-version:	 go1.3.3
dependency:	 bitbucket.org/tebeka/strftime 2194253a23c090a4d5953b152a3c63fb5da4f5a4 0.1.2-4
dependency:	 github.com/AlekSi/airbrake-go 93a91a338f77e7bcf1447c4ae3afe848d62a45cd
dependency:	 github.com/Scalingo/go-etcd-lock/lock a39e1fe285d1134060650a3dc4284203614ecdf3 v0.2-2-ga39e1fe
new dependency:	 github.com/Scalingo/gopassword 5e9b4ab86ad3f192d3b75b36f4e6efef4eadcccf
new dependency:	 github.com/Scalingo/logrus-airbrake 240f37235524a9567ec922948c458a87fda2f9e0
dependency:	 github.com/Sirupsen/logrus c13432b0a52fa22ed08301e522a0bdb2ce0e2d40 v0.5.1-2-gc13432b
dependency:	 github.com/Soulou/acadock-monitoring/client f51550868981f956fba95beaac4f425261c29bda v0.1.1
dependency:	 github.com/codegangsta/inject 4b8172520a03fa190f427bbd284db01b459bfce7 v1.0-rc1-4-g4b81725
dependency:	 github.com/coreos/go-etcd/etcd 23142f6773a676cc2cae8dd0cb90b2ea761c853f v0.2.0-rc1-120-g23142f6
dependency:	 github.com/go-martini/martini 7d32ea3fa6590565c928b90a48178b60b96df98f v1.0-50-g7d32ea3
dependency:	 github.com/gorilla/handlers 0e84b7d810c16aed432217e330206be156bafae0
dependency:	 github.com/lib/pq c6325123e6d45115749734a8bc35060ebac74d0e
dependency:	 github.com/martini-contrib/auth 7925ee933d02cb66101819126f8b39367994c2b2
dependency:	 github.com/robfig/cron b024fc5ea0e34bc3f83d9941c8d60b0622bfaca4 v1-3-gb024fc5
dependency:	 gopkg.in/Scalingo/etcd-discovery.v2/service 191c3af21099f20b41d8486b9310ceeff78fd168 v2.0
dependency:	 gopkg.in/errgo.v1 1a3d4d77253d47458a42542b4c0bf709fcd5d715
dependency:	 gopkg.in/mgo.v2 c9fd3712fbf3e92924c974dce16da2d322508fe2
copy:	 /home/leo/Projects/Go/src/github.com/Scalingo/gopassword → Godeps/_workspace/src/github.com/Scalingo/gopassword
copy:	 /home/leo/Projects/Go/src/github.com/Scalingo/logrus-airbrake → Godeps/_workspace/src/github.com/Scalingo/logrus-airbrake
rewrite Godeps/_workspace/src/github.com/Scalingo/logrus-airbrake/examples/test.go:
  "github.com/AlekSi/airbrake-go" → /home/soulou/go/src/github.com/Scalingo/appsdeck-database/Godeps/_workspace/src/github.com/AlekSi/airbrake-go
rewrite Godeps/_workspace/src/github.com/Scalingo/logrus-airbrake/examples/test.go:
  "github.com/Sirupsen/logrus" → /home/soulou/go/src/github.com/Scalingo/appsdeck-database/Godeps/_workspace/src/github.com/Sirupsen/logrus
rewrite Godeps/_workspace/src/github.com/Scalingo/logrus-airbrake/hook.go:
  "github.com/AlekSi/airbrake-go" → /home/soulou/go/src/github.com/Scalingo/appsdeck-database/Godeps/_workspace/src/github.com/AlekSi/airbrake-go
rewrite Godeps/_workspace/src/github.com/Scalingo/logrus-airbrake/hook.go:
  "github.com/Sirupsen/logrus" → /home/soulou/go/src/github.com/Scalingo/appsdeck-database/Godeps/_workspace/src/github.com/Sirupsen/logrus
```

What do you think about that? What would you display?