### PR TITLE
godep save: Add interactive `-p` option

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,6 +53,7 @@ type Dependency struct {
 func (g *Godeps) Load(pkgs []*Package) error {
 	var err1 error
 	var path, seen []string
+	reader := bufio.NewReader(os.Stdin)
 	for _, p := range pkgs {
 		if p.Standard {
 			log.Println("ignoring stdlib package:", p.ImportPath)
@@ -130,6 +132,13 @@ func (g *Godeps) Load(pkgs []*Package) error {
 			log.Println("dirty working tree:", pkg.Dir)
 			err1 = errors.New("error loading dependencies")
 			continue
+		}
+		if saveP {
+			fmt.Printf("godep: Would you like to index %s ?\n[Y/n]:", pkg.ImportPath)
+			text, _ := reader.ReadString('\n')
+			if text[0] == 'n' {
+				continue
+			}
 		}
 		comment := vcs.describe(pkg.Dir, id)
 		g.Deps = append(g.Deps, Dependency{

--- a/save.go
+++ b/save.go
@@ -14,7 +14,7 @@ import (
 )
 
 var cmdSave = &Command{
-	Usage: "save [-r] [packages]",
+	Usage: "save [-r] [-p] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 Save writes a list of the dependencies of the named packages along
@@ -43,6 +43,9 @@ To update a dependency to a newer revision, use 'godep update'.
 If -r is given, import statements will be rewritten to refer
 directly to the copied source code.
 
+If -p is given, godep will ask user confirmation before adding
+a package into dependency list
+
 For more about specifying packages, see 'go help packages'.
 `,
 	Run: runSave,
@@ -51,11 +54,13 @@ For more about specifying packages, see 'go help packages'.
 var (
 	saveCopy = true
 	saveR    = false
+	saveP    = false
 )
 
 func init() {
 	cmdSave.Flag.BoolVar(&saveCopy, "copy", true, "copy source code")
 	cmdSave.Flag.BoolVar(&saveR, "r", false, "rewrite import paths")
+	cmdSave.Flag.BoolVar(&saveP, "p", false, "interactive mode")
 }
 
 func runSave(cmd *Command, args []string) {


### PR DESCRIPTION
With some projects splitted in several repositories, it comes handy to be able to select dependencies manually.

Inspired by `git add` command.
See : http://git-scm.com/docs/git-add