### PR TITLE
Copy tracked files only

### DIFF
--- a/save_test.go
+++ b/save_test.go
@@ -975,6 +975,39 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // don't copy untracked files in the source directory
+			cwd: "C",
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main", "D"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"main.go", pkg("D"), nil},
+						{"+git", "D1", nil},
+						{"untracked", "garbage", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main", "D"), nil},
+				{"C/Godeps/_workspace/src/D/main.go", pkg("D"), nil},
+				{"C/Godeps/_workspace/src/D/untracked", "(absent)", nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()


### PR DESCRIPTION
This pull request adds a new VCS command to list all tracked files in a repository. When copying files, godep uses that list to make sure only tracked files are copied.

Closes #102 
