### PR TITLE
Don't copy GIT_ env variables so we can run godep in a githook

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -194,6 +194,12 @@ func (v *VCS) run1(dir string, cmdline string, kv []string, verbose bool) ([]byt
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
+	cmd.Env = make([]string, 0)
+	for _, kv := range os.Environ() {
+		if !strings.HasPrefix(kv, "GIT_") {
+			cmd.Env = append(cmd.Env, kv)
+		}
+	}
 	err = cmd.Run()
 	out := buf.Bytes()
 	if err != nil {


### PR DESCRIPTION
When running `git` we should not copy all environment variables. When `godep` is run from a `githook` git will set some environment variables like `GIT_DIR` and `GIT_INDEX_FILE`. These variables end up being set for the `git` command run by `godep` which prevents it from working correctly. `git` seems to prefer the variables set in the environment before `--git-dir=` and will somehow complain that the directory is not a repository.

I know that removing the environment variables in `run1` is a bit nasty seeing that this function is also being used to run commands for other vcs's. I could add a field in the `VCS` which sets the prefix of environment variables to be removed. I'm not sure if that is a more clean and future proof.