### PR TITLE
Rootset

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -49,9 +49,9 @@ type Dependency struct {
 }
 
 // pkgs is the list of packages to read dependencies
-func (g *Godeps) Load(pkgs []*Package) error {
+func (g *Godeps) Load(pkgs []*Package, destImportPath string) error {
 	var err1 error
-	var path, seen []string
+	var path []string
 	for _, p := range pkgs {
 		if p.Standard {
 			log.Println("ignoring stdlib package:", p.ImportPath)
@@ -62,13 +62,7 @@ func (g *Godeps) Load(pkgs []*Package) error {
 			err1 = errors.New("error loading packages")
 			continue
 		}
-		_, reporoot, err := VCSFromDir(p.Dir, filepath.Join(p.Root, "src"))
-		if err != nil {
-			log.Println(err)
-			err1 = errors.New("error loading packages")
-			continue
-		}
-		seen = append(seen, filepath.ToSlash(reporoot))
+		path = append(path, p.ImportPath)
 		path = append(path, p.Deps...)
 	}
 	var testImports []string
@@ -101,25 +95,23 @@ func (g *Godeps) Load(pkgs []*Package) error {
 	if err != nil {
 		return err
 	}
+	seen := []string{destImportPath}
 	for _, pkg := range ps {
 		if pkg.Error.Err != "" {
 			log.Println(pkg.Error.Err)
 			err1 = errors.New("error loading dependencies")
 			continue
 		}
-		if pkg.Standard {
+		if pkg.Standard || containsPathPrefix(seen, pkg.ImportPath) {
 			continue
 		}
+		seen = append(seen, pkg.ImportPath)
 		vcs, reporoot, err := VCSFromDir(pkg.Dir, filepath.Join(pkg.Root, "src"))
 		if err != nil {
 			log.Println(err)
 			err1 = errors.New("error loading dependencies")
 			continue
 		}
-		if containsPathPrefix(seen, pkg.ImportPath) {
-			continue
-		}
-		seen = append(seen, pkg.ImportPath)
 		id, err := vcs.identify(pkg.Dir)
 		if err != nil {
 			log.Println(err)

--- a/save.go
+++ b/save.go
@@ -15,11 +15,13 @@ import (
 
 var cmdSave = &Command{
 	Usage: "save [-r] [-copy=false] [packages]",
-	Short: "list and copy dependencies into Godeps",
+	Short: "list and copy packages into Godeps",
 	Long: `
-Save writes a list of the dependencies of the named packages along
-with the exact source control revision of each dependency, and copies
-their source code into a subdirectory.
+
+Save writes a list of the named packages and their dependencies along
+with the exact source control revision of each package, and copies
+their source code into a subdirectory. Packages inside . are excluded
+from the list to be copied.
 
 The dependency list is a JSON document with the following structure:
 
@@ -34,7 +36,7 @@ The dependency list is a JSON document with the following structure:
 		}
 	}
 
-Any dependencies already present in the list will be left unchanged.
+Any packages already present in the list will be left unchanged.
 To update a dependency to a newer revision, use 'godep update'.
 
 If -r is given, import statements will be rewritten to refer
@@ -43,7 +45,7 @@ directly to the copied source code.
 If -copy=false is given, the list alone is written to file Godeps.
 
 Otherwise, the list is written to Godeps/Godeps.json, and source
-code for all dependencies is copied into Godeps/_workspace.
+code for the packages is copied into Godeps/_workspace.
 
 For more about specifying packages, see 'go help packages'.
 `,
@@ -98,7 +100,7 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	err = gnew.Load(a)
+	err = gnew.Load(a, dot[0].ImportPath)
 	if err != nil {
 		return err
 	}

--- a/save_test.go
+++ b/save_test.go
@@ -891,6 +891,58 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // don't require packages contained in dest to be in VCS
+			cwd:   "C",
+			flagR: true,
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main"), nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps:       []Dependency{},
+			},
+		},
+		{ // include command line packages in the set to be copied
+			cwd:   "C",
+			args:  []string{"P"},
+			flagR: true,
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main"), nil},
+					},
+				},
+				{
+					"P",
+					"",
+					[]*node{
+						{"main.go", pkg("P"), nil},
+						{"+git", "P1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main"), nil},
+				{"C/Godeps/_workspace/src/P/main.go", pkg("P"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "P", Comment: "P1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()


### PR DESCRIPTION
This performs a backmerge of the current state of master into this aging rootset branch.  I've verified the changes are consistent with the original rootset branch, and we've tested it in a project in which we needed this additional functionality.

My goal is to get this backmerge done, and then lobby for merging tools/godep/rootset into tools/godep/master such that this is codified as supported.  This appears to solve #43 #48 and #108.