### PR TITLE
add default omit patterns, and a omit cli flag

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -42,10 +42,13 @@ type Dependency struct {
 }
 
 // pkgs is the list of packages to read dependencies
-func (g *Godeps) Load(pkgs []*Package) error {
+func (g *Godeps) Load(pkgs []*Package, omitPkgs []string) error {
 	var err1 error
 	var path, seen []string
 	for _, p := range pkgs {
+		if omitPkg(p.ImportPath, omitPkgs) {
+			continue
+		}
 		if p.Standard {
 			log.Println("ignoring stdlib package:", p.ImportPath)
 			continue
@@ -74,6 +77,9 @@ func (g *Godeps) Load(pkgs []*Package) error {
 		return err
 	}
 	for _, p := range ps {
+		if omitPkg(p.ImportPath, omitPkgs) {
+			continue
+		}
 		if p.Standard {
 			continue
 		}
@@ -95,6 +101,9 @@ func (g *Godeps) Load(pkgs []*Package) error {
 		return err
 	}
 	for _, pkg := range ps {
+		if omitPkg(pkg.ImportPath, omitPkgs) {
+			continue
+		}
 		if pkg.Error.Err != "" {
 			log.Println(pkg.Error.Err)
 			err1 = errors.New("error loading dependencies")

--- a/pkg.go
+++ b/pkg.go
@@ -28,6 +28,20 @@ type Package struct {
 	}
 }
 
+var defaultOmitPatterns = []string{
+	"appengine/...",
+	"appengine_internal/...",
+}
+
+func omitPkg(importPath string, omitPkgs []string) bool {
+	for _, pattern := range append(omitPkgs, defaultOmitPatterns...) {
+		if matchPattern(pattern)(importPath) {
+			return true
+		}
+	}
+	return false
+}
+
 // LoadPackages loads the named packages using go list -json.
 // Unlike the go tool, an empty argument list is treated as
 // an empty list; "." must be given explicitly if desired.

--- a/save.go
+++ b/save.go
@@ -17,7 +17,7 @@ import (
 )
 
 var cmdSave = &Command{
-	Usage: "save [-r] [packages]",
+	Usage: "save [-r] [-omit=package1,package2...] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 Save writes a list of the dependencies of the named packages along
@@ -51,14 +51,26 @@ For more about specifying packages, see 'go help packages'.
 	Run: runSave,
 }
 
+type list []string
+
+func (l *list) String() string {
+	return strings.Join(*l, ",")
+}
+func (l *list) Set(value string) error {
+	*l = strings.Split(value, ",")
+	return nil
+}
+
 var (
-	saveCopy = true
-	saveR    = false
+	saveCopy      = true
+	saveR         = false
+	saveOmit list = []string{}
 )
 
 func init() {
 	cmdSave.Flag.BoolVar(&saveCopy, "copy", true, "copy source code")
 	cmdSave.Flag.BoolVar(&saveR, "r", false, "rewrite import paths")
+	cmdSave.Flag.Var(&saveOmit, "omit", "comma-separated list of packages to omit")
 }
 
 func runSave(cmd *Command, args []string) {
@@ -100,7 +112,7 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	err = gnew.Load(a)
+	err = gnew.Load(a, saveOmit)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Proposed fix for #103 

Omit appengine and appengine_internal by default, and adds a omit
flag for other package patterns.