### PR TITLE
More verbose error in VCSFromDir to indentify problem package

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -59,7 +59,7 @@ var cmd = map[*vcs.Cmd]*VCS{
 func VCSFromDir(dir, srcRoot string) (*VCS, string, error) {
 	vcscmd, reporoot, err := vcs.FromDir(dir, srcRoot)
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("error inspecting %q for VCS: %v", dir, err)
 	}
 	vcsext := cmd[vcscmd]
 	if vcsext == nil {


### PR DESCRIPTION
I recently found it quite difficult to figure out why `godep save` was failing, because the error message was a bit too generic:

```
godep: directory $GOPATH is not using any known version control system
godep: error loading dependencies
```

After adding some print statements and rebuilding godep, I found out that one of my libraries in my $GOPATH had been installed as a pure source download, instead of a valid repo. The problem is that this error is bubbled up from `go.tools/go/vcs/vcs.go`, which tries to walk up the paths to find a repo. When it returns this error message that I see, it contains a path that has already been walked up. 

I've added an extended error message to `VCSFromDir()` to ensure that the problem package is printed and easily identifiable to the user. 
