### PR TITLE
rewrite: remove existing file before moving the temp file into place.

### DIFF
--- a/rewrite.go
+++ b/rewrite.go
@@ -97,6 +97,13 @@ func rewriteGoFile(name, qual string, paths []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Windows doesn't allow a rename over an existing file.
+	err = os.Remove(name)
+	if err != nil {
+		return err
+	}
+
 	return os.Rename(wpath, name)
 }
 


### PR DESCRIPTION
Windows doesn't allow a rename over an existing file.

The other way to fix this problem on windows is to do a three step rename old (".old"), rename new, then delete old. However, I think this is fine.