### PR TITLE
Fix support for git submodule and skip all files starting with '.' or '_'

### DIFF
--- a/save.go
+++ b/save.go
@@ -295,11 +295,15 @@ func copyPkgFile(dstroot, srcroot string, w *fs.Walker) error {
 	if w.Err() != nil {
 		return w.Err()
 	}
-	if c := w.Stat().Name()[0]; c == '.' || c == '_' {
-		// Skip directories using a rule similar to how
-		// the go tool enumerates packages.
-		// See $GOROOT/src/cmd/go/main.go:/matchPackagesInFs
-		w.SkipDir()
+	name := w.Stat().Name()
+	if c := name[0]; c == '.' || c == '_' {
+		if w.Stat().IsDir() {
+			// Skip directories using a rule similar to how
+			// the go tool enumerates packages.
+			// See $GOROOT/src/cmd/go/main.go:/matchPackagesInFs
+			w.SkipDir()
+		}
+		return nil
 	}
 	if w.Stat().IsDir() {
 		return nil
@@ -395,7 +399,7 @@ func stripImportComment(line []byte) []byte {
 // It logs any errors it encounters.
 func writeVCSIgnore(dir string) {
 	// Currently git is the only VCS for which we know how to do this.
-	// Mercurial and Bazaar have similar mechasims, but they apparently
+	// Mercurial and Bazaar have similar mechanisms, but they apparently
 	// require writing files outside of dir.
 	const ignore = "/pkg\n/bin\n"
 	name := filepath.Join(dir, ".gitignore")

--- a/save_test.go
+++ b/save_test.go
@@ -224,6 +224,46 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // transitive dependency with source starting with '_'
+			cwd: "C",
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main", "D"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"_ignored.go", pkg("D", "T"), nil},
+						{"main.go", pkg("D"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+				{
+					"T",
+					"",
+					[]*node{
+						{"main.go", pkg("T"), nil},
+						{"+git", "T1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main", "D"), nil},
+				{"C/Godeps/_workspace/src/D/main.go", pkg("D"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 		{ // two packages, one in a subdirectory
 			cwd: "C",
 			start: []*node{


### PR DESCRIPTION
When fetching a git repository with --recursive, it creates a '.git' file
instead of a '.git' directory. This confused this copyPkgFile() directory
skipping logic which assumed only directories starting with '.' are skipped.

When using 'git add Godeps', git complained with:
  fatal: Not a git repository: Godeps/_workspace/src/<path/to/pkg>/<modulename>/../.git/modules/<modulename>
