### PR TITLE
Support for resolving symbolic links 

### DIFF
--- a/save.go
+++ b/save.go
@@ -276,10 +276,30 @@ func copySrc(dir string, deps []Dependency) error {
 			log.Println(err)
 			ok = false
 		}
-		w := fs.Walk(dep.dir)
+
+		var walkDir string
+		if walkDir, err = filepath.EvalSymlinks(dep.dir); err != nil {
+			return err
+		}
+
+		w := fs.Walk(walkDir)
 		for w.Step() {
-			err = copyPkgFile(dir, srcdir, w)
+			// project the relative (symlink) dir to the src dir
+			rel, err := filepath.Rel(walkDir, w.Path())
 			if err != nil {
+				log.Println(err)
+				ok = false
+				continue
+			}
+
+			if rel, err = filepath.Rel(srcdir, filepath.Join(dep.dir, rel)); err != nil {
+				log.Println(err)
+				ok = false
+				continue
+			}
+
+			dst := filepath.Join(dir, rel)
+			if err = copyPkgFile(dst, w.Path(), w); err != nil {
 				log.Println(err)
 				ok = false
 			}
@@ -291,7 +311,7 @@ func copySrc(dir string, deps []Dependency) error {
 	return nil
 }
 
-func copyPkgFile(dstroot, srcroot string, w *fs.Walker) error {
+func copyPkgFile(dst, path string, w *fs.Walker) error {
 	if w.Err() != nil {
 		return w.Err()
 	}
@@ -304,11 +324,7 @@ func copyPkgFile(dstroot, srcroot string, w *fs.Walker) error {
 	if w.Stat().IsDir() {
 		return nil
 	}
-	rel, err := filepath.Rel(srcroot, w.Path())
-	if err != nil { // this should never happen
-		return err
-	}
-	return copyFile(filepath.Join(dstroot, rel), w.Path())
+	return copyFile(dst, path)
 }
 
 // copyFile copies a regular file from src to dst.


### PR DESCRIPTION
This should fix issue #71. It will resolve eventual symbolic links and project them on the source folder. This allows to create symbolic links from several projects to the gopath folder.

I've seen the discussion around this, and if you still prefer **won't fix** just ignore and close this PR ;-)