### PR TITLE
Rewrite should ignore symbolic linked .go file

### DIFF
--- a/rewrite.go
+++ b/rewrite.go
@@ -48,11 +48,20 @@ func rewriteTree(path, qual string, paths []string) error {
 			log.Println("rewrite:", w.Err())
 			continue
 		}
-		if !w.Stat().IsDir() && strings.HasSuffix(w.Path(), ".go") {
-			err := rewriteGoFile(w.Path(), qual, paths)
+		filePath := w.Path()
+		if !w.Stat().IsDir() && strings.HasSuffix(filePath, ".go") {
+			fileInfo, err := os.Lstat(filePath)
 			if err != nil {
 				return err
 			}
+
+			if fileInfo.Mode() != os.ModeSymlink {
+				err = rewriteGoFile(filePath, qual, paths)
+				if err != nil {
+					return err
+				}
+			}
+
 		}
 	}
 	return nil


### PR DESCRIPTION
Hi,

We have use cases of keeping symbolic linked `.go` files in the project root directory. The current  rewrite logic modifies the symbolic link files when `godep save ./...` is executed.

This PR ensures the rewrite logic leave symbolic link file untouched.

Thank you