### PR TITLE
GFW golang.org

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/tools/go/vcs"
+	"github.com/golang/tools/go/vcs"
 )
 
 type VCS struct {


### PR DESCRIPTION
Hi,

Because of the nasty GFW from the Chinese government, golang.org can't be accessed from China especially in shell like "go get github.com/tools/godep", so I replace "golang.org/x/tools" with its mirror "github.com/golang/tools".

Would you please accept the pull request for this reason?

Thank you