### PR TITLE
Respect the GO15VENDOREXPERIMENT env variable

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -128,3 +128,33 @@ Example Godeps:
 	]
 }
 ```
+
+### Go 1.5 vendor/ experiment
+
+Godep has preliminary support for the Go 1.5 vendor/ [experiment](https://github.com/golang/go/commit/183cc0cd41f06f83cb7a2490a499e3f9101befff)
+utilizing the same environment variable that the go tooling itself supports:
+`export GO15VENDOREXPERIMENT=1`
+
+When `GO15VENDOREXPERIMENT=1` godep will write the vendored code into the local
+package's `vendor` directory. A `Godeps/Godeps.json` file is created, just like
+during normal operation. The vendor experiment is not compatible with rewrites.
+
+There is currently no automated migration between the old Godeps workspace and
+the vendor directory, but the following steps should work:
+
+```term
+$ unset GO15VENDOREXPERIMENT
+$ godep restore
+# The next line is only needed to automatically undo rewritten imports that were
+# created with godep save -r.
+$ godep save ./...
+$ rm -rf Godeps
+$ export GO15VENDOREXPERIMENT=1
+$ godep save ./...
+$ git add -A
+# You should see your Godeps/_workspace/src files "moved" to vendor/.
+```
+
+NOTE: There is a "bug" in the vendor experiment that makes using `./...` with
+the go tool (like go install) consider all packages inside the vendor directory:
+https://github.com/golang/go/issues/11659.

--- a/rewrite.go
+++ b/rewrite.go
@@ -106,16 +106,19 @@ func rewriteGoFile(name, qual string, paths []string) error {
 	return os.Rename(wpath, name)
 }
 
-// sep is the signature set of path elements that
-// precede the original path of an imported package
-// in a rewritten import path.
-var sep = "/Godeps/_workspace/src/"
+// VendorExperiment is the Go 1.5 vendor directory experiment flag, see
+// https://github.com/golang/go/commit/183cc0cd41f06f83cb7a2490a499e3f9101befff
 var VendorExperiment = os.Getenv("GO15VENDOREXPERIMENT") == "1"
 
-func init() {
+// sep is the signature set of path elements that
+// precede the original path of an imported package.
+var sep = defaultSep(VendorExperiment)
+
+func defaultSep(experiment bool) string {
 	if VendorExperiment {
-		sep = "/vendor/"
+		return "/vendor/"
 	}
+	return "/Godeps/_workspace/src/"
 }
 
 // unqualify returns the part of importPath after the last

--- a/rewrite.go
+++ b/rewrite.go
@@ -115,7 +115,7 @@ var VendorExperiment = os.Getenv("GO15VENDOREXPERIMENT") == "1"
 var sep = defaultSep(VendorExperiment)
 
 func defaultSep(experiment bool) string {
-	if VendorExperiment {
+	if experiment {
 		return "/vendor/"
 	}
 	return "/Godeps/_workspace/src/"

--- a/rewrite.go
+++ b/rewrite.go
@@ -109,7 +109,14 @@ func rewriteGoFile(name, qual string, paths []string) error {
 // sep is the signature set of path elements that
 // precede the original path of an imported package
 // in a rewritten import path.
-const sep = "/Godeps/_workspace/src/"
+var sep = "/Godeps/_workspace/src/"
+var VendorExperiment = os.Getenv("GO15VENDOREXPERIMENT") == "1"
+
+func init() {
+	if VendorExperiment {
+		sep = "/vendor/"
+	}
+}
 
 // unqualify returns the part of importPath after the last
 // occurrence of the signature path elements

--- a/save.go
+++ b/save.go
@@ -26,7 +26,7 @@ their source code into a subdirectory.
 
 The list is written to Godeps/Godeps.json, and source code for all
 dependencies is copied into either Godeps/_workspace or, if the vendor
-experiment it turned on, vendor.
+experiment is turned on, vendor/.
 
 The dependency list is a JSON document with the following structure:
 

--- a/save.go
+++ b/save.go
@@ -25,7 +25,8 @@ with the exact source control revision of each dependency, and copies
 their source code into a subdirectory.
 
 The list is written to Godeps/Godeps.json, and source code for all
-dependencies is copied into Godeps/_workspace.
+dependencies is copied into either Godeps/_workspace or, if the vendor
+experiment it turned on, vendor.
 
 The dependency list is a JSON document with the following structure:
 
@@ -44,7 +45,8 @@ Any dependencies already present in the list will be left unchanged.
 To update a dependency to a newer revision, use 'godep update'.
 
 If -r is given, import statements will be rewritten to refer
-directly to the copied source code.
+directly to the copied source code. This is not compatible with the
+vendor experiment.
 
 For more about specifying packages, see 'go help packages'.
 `,
@@ -62,6 +64,10 @@ func init() {
 }
 
 func runSave(cmd *Command, args []string) {
+	if VendorExperiment && saveR {
+		log.Println("flag -r is incompatible with the vendoring experiment")
+		cmd.UsageExit()
+	}
 	if !saveCopy {
 		log.Println("flag unsupported: -copy=false")
 		cmd.UsageExit()
@@ -145,8 +151,7 @@ func save(pkgs []string) error {
 	// ignores this directory when traversing packages
 	// starting at the project's root. For example,
 	//   godep go list ./...
-	workspace := filepath.Join("Godeps", "_workspace")
-	srcdir := filepath.Join(workspace, "src")
+	srcdir := filepath.FromSlash(strings.Trim(sep, "/"))
 	rem := subDeps(gold.Deps, gnew.Deps)
 	add := subDeps(gnew.Deps, gold.Deps)
 	err = removeSrc(srcdir, rem)
@@ -157,7 +162,10 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	writeVCSIgnore(workspace)
+	if !VendorExperiment {
+		f, _ := filepath.Split(srcdir)
+		writeVCSIgnore(f)
+	}
 	var rewritePaths []string
 	if saveR {
 		for _, dep := range gnew.Deps {


### PR DESCRIPTION
The GO15VENDOREXPERIMENT env variable is how the vendor experiment is
enabled and we should respect that and use it when the user has it set.

@kr ... I think this is something (with maybe a little more work) we should actually incorporate sooner rather than later. Thoughts?