### PR TITLE
Instruct user on how to resolve "dirty working tree" problem

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -120,7 +120,7 @@ func (g *Godeps) Load(pkgs []*Package) error {
 			continue
 		}
 		if vcs.isDirty(pkg.Dir, id) {
-			log.Println("dirty working tree:", pkg.Dir)
+			log.Println("dirty working tree (please commit changes):", pkg.Dir)
 			err1 = errors.New("error loading dependencies")
 			continue
 		}

--- a/update.go
+++ b/update.go
@@ -222,7 +222,7 @@ func LoadVCSAndUpdate(deps []Dependency) ([]Dependency, error) {
 			continue
 		}
 		if dep.vcs.isDirty(dep.pkg.Dir, id) {
-			log.Println("dirty working tree:", dep.pkg.Dir)
+			log.Println("dirty working tree (please commit changes):", dep.pkg.Dir)
 			err1 = errors.New("error loading dependencies")
 			break
 		}


### PR DESCRIPTION
Provides a slightly more helpful error message that continue to present
the problem, but also gives the user a hint on how to resolve it. This
may save some people a trip to Google and back.

@kr I ran into this one and had to land on #24 via Google because it
wasn't too intuitive to me what I should do about it. Would you consider 
this slightly expanded error message to provide a little extra help? 
Thanks!

Helps address #24.