### PR TITLE
godep version command

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"text/template"
 )
@@ -74,6 +75,11 @@ func main() {
 
 	if args[0] == "help" {
 		help(args[1:])
+		return
+	}
+
+	if args[0] == "version" {
+		fmt.Printf("godep v%d (%s/%s/%s)\n", version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 		return
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const version = 1


### PR DESCRIPTION
Output the version as well as some go runtime information that is
useful for debugging user's issues.

The `version` const would be bumped each time a PR is merged into master
to ensure that we'll be able to tell which version someone got when they
did a `go get github.com/tools/godep`.

This is similar to what github.com/kr/okjson does.

Other suggestions welcome, but I need to introduce the idea of a version
for debugging purposes.

@kr This is what we spoke about @ Gophercon
/cc @neurogeek 