### PR TITLE
Be explicit that without -r you need to set GOPATH

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,16 @@ import C/Godeps/_workspace/src/D. This makes C's repo
 self-contained and causes 'go get' to build C with the
 right version of all dependencies.
 
+If you don't use `-r`, then in order to use the fixed dependencies and get
+reproducible builds, you must make sure that **every time** you run a Go-related
+command, you wrap it in one of these two ways:
+
+- If the command you are running is just `go`, run it as `godep go ...`, e.g.
+  `godep go install -v ./...`
+
+- When using a different command, set your `$GOPATH` using `godep path` as
+  described below.
+
 #### Restore
 
 The `godep restore` command is the opposite of `godep save`.


### PR DESCRIPTION
I just joined a team that believed they were using `godep`... except we don't use `-r` and none of our build scripts used `godep go` or `godep path`.  I realize it's kind of documented already, but I wanted to add a really explicit statement that you have to do one of these things or else you will silently end up with non-reproducible builds.