### PR TITLE
continue try other package instead of exit whole process

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -169,8 +169,11 @@ func ReadAndLoadGodeps(path string) (*Godeps, error) {
 		d := &g.Deps[i]
 		d.vcs, err = VCSForImportPath(d.ImportPath)
 		if err != nil {
-			log.Printf("fetch %s failure", d.ImportPath)
-			continue
+			if skipError {
+				log.Printf("fetch %s failure but skipped", d.ImportPath)
+				continue
+			}
+			return nil, err
 		}
 		avs = append(avs, g.Deps[i])
 	}

--- a/dep.go
+++ b/dep.go
@@ -164,13 +164,17 @@ func ReadAndLoadGodeps(path string) (*Godeps, error) {
 		return nil, err
 	}
 
+	var avs []Dependency
 	for i := range g.Deps {
 		d := &g.Deps[i]
 		d.vcs, err = VCSForImportPath(d.ImportPath)
 		if err != nil {
-			return nil, err
+			log.Printf("fetch %s failure", d.ImportPath)
+			continue
 		}
+		avs = append(avs, g.Deps[i])
 	}
+	g.Deps = avs
 	return g, nil
 }
 

--- a/restore.go
+++ b/restore.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 )
 
+var skipError = false
+
 var cmdRestore = &Command{
 	Usage: "restore [-v]",
 	Short: "check out listed dependency versions in GOPATH",
@@ -19,6 +21,7 @@ If -v is given, verbose output is enabled.
 
 func init() {
 	cmdRestore.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
+	cmdRestore.Flag.BoolVar(&skipError, "skipError", false, "skip error package")
 }
 
 func runRestore(cmd *Command, args []string) {


### PR DESCRIPTION
It's better to continue try other one instead of exit whole process when meet failure duaring `restore` command fetch pkg

In China, our network is under GreatFireWall..

so we need A vpn to get google dep, and B vpn to get others..

it's better do some warn and go on fetch other package..then we can try multi-time to get all deps - -!

I tried to do something like `go get without -u` first see loacal, then decide is need to fetch though network...but it's not easy to implement that so...try this one first~