### PR TITLE
Do not parse Go files in testdata directories.

### DIFF
--- a/rewrite.go
+++ b/rewrite.go
@@ -42,6 +42,7 @@ func pkgFiles(pkgs []*Package) []string {
 
 // rewriteTree recursively visits the go files in path, rewriting
 // import statments according to the rules for func qualify.
+// This function ignores the 'testdata' directory.
 func rewriteTree(path, qual string, paths []string) error {
 	w := fs.Walk(path)
 	for w.Step() {
@@ -49,7 +50,11 @@ func rewriteTree(path, qual string, paths []string) error {
 			log.Println("rewrite:", w.Err())
 			continue
 		}
-		if !w.Stat().IsDir() && strings.HasSuffix(w.Path(), ".go") {
+		s := w.Stat()
+		if s.IsDir() && s.Name() == "testdata" {
+			w.SkipDir()
+		}
+		if !s.IsDir() && strings.HasSuffix(w.Path(), ".go") {
 			err := rewriteGoFile(w.Path(), qual, paths)
 			if err != nil {
 				return err

--- a/rewrite.go
+++ b/rewrite.go
@@ -51,14 +51,18 @@ func rewriteTree(path, qual string, paths []string) error {
 			continue
 		}
 		s := w.Stat()
-		if s.IsDir() && s.Name() == "testdata" {
-			w.SkipDir()
-			continue
-		}
-		if !s.IsDir() && strings.HasSuffix(w.Path(), ".go") {
-			err := rewriteGoFile(w.Path(), qual, paths)
-			if err != nil {
-				return err
+		switch s.IsDir() {
+		case true:
+			if s.Name() == "testdata" {
+				w.SkipDir()
+				continue
+			}
+		case false:
+			if strings.HasSuffix(w.Path(), ".go") {
+				err := rewriteGoFile(w.Path(), qual, paths)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/rewrite.go
+++ b/rewrite.go
@@ -53,6 +53,7 @@ func rewriteTree(path, qual string, paths []string) error {
 		s := w.Stat()
 		if s.IsDir() && s.Name() == "testdata" {
 			w.SkipDir()
+			continue
 		}
 		if !s.IsDir() && strings.HasSuffix(w.Path(), ".go") {
 			err := rewriteGoFile(w.Path(), qual, paths)

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -218,6 +218,26 @@ func TestRewrite(t *testing.T) {
 				{"C/main.go", sortOrderPreserveCommentRewritten, nil},
 			},
 		},
+		{ // testdata directory is copied unmodified.
+			cwd:   "C",
+			paths: []string{"D"},
+			start: []*node{
+				{"C/main.go", pkg("main", "D"), nil},
+				{"C/testdata", "",
+					[]*node{
+						{"badpkg.go", "//", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main", "C/Godeps/_workspace/src/D"), nil},
+				{"C/testdata", "",
+					[]*node{
+						{"badpkg.go", "//", nil},
+					},
+				},
+			},
+		},
 	}
 
 	const gopath = "godeptest"

--- a/save.go
+++ b/save.go
@@ -305,8 +305,7 @@ func copyPkgFile(dstroot, srcroot string, w *fs.Walker) error {
 	if w.Err() != nil {
 		return w.Err()
 	}
-	n := w.Stat().Name()
-	if n[0] == '.' || n[0] == '_' || n == "testdata" {
+	if c := w.Stat().Name()[0]; c == '.' || c == '_' {
 		// Skip directories using a rule similar to how
 		// the go tool enumerates packages.
 		// See $GOROOT/src/cmd/go/main.go:/matchPackagesInFs

--- a/save_test.go
+++ b/save_test.go
@@ -975,42 +975,6 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
-		{ // ignore files in testdata, see https://github.com/tools/godep/issues/140
-			cwd: "C",
-			start: []*node{
-				{
-					"C",
-					"",
-					[]*node{
-						{"main.go", pkg("main", "D"), nil},
-						{"+git", "", nil},
-					},
-				},
-				{
-					"D",
-					"",
-					[]*node{
-						{"main.go", pkg("D"), nil},
-						{"+git", "D1", nil},
-						{"testdata", "",
-							[]*node{
-								{"test1.go", "import E", nil},
-							},
-						},
-					},
-				},
-			},
-			want: []*node{
-				{"C/main.go", pkg("main", "D"), nil},
-				{"C/Godeps/_workspace/src/D/main.go", pkg("D"), nil},
-			},
-			wdep: Godeps{
-				ImportPath: "C",
-				Deps: []Dependency{
-					{ImportPath: "D", Comment: "D1"},
-				},
-			},
-		},
 	}
 
 	wd, err := os.Getwd()

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = 3
+const version = 4


### PR DESCRIPTION
Revert ignoring testdata directories and instead, ignore it during the rewrite of Go files and copy the whole directory unmodified.

This commit fixes issue #140