### PR TITLE
Don't save test dependencies by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,8 +25,13 @@ $ godep save -r
 
 This will save a list of dependencies to the file `Godeps/Godeps.json`, copy
 their source code into `Godeps/_workspace` and rewrite the dependencies. Godep
-does not copy files from source repositories that are not tracked (in version
-control). Read over the contents of `Godeps/_workspace` and make sure it looks
+does **not copy**:
+
+- files from source repositories that are not tracked in version control.
+- `*_test.go` files.
+- `testdata` directories.
+
+Read over the contents of `Godeps/_workspace` and make sure it looks
 reasonable. Then commit the whole Godeps directory to version control,
 **including `Godeps/_workspace`**.
 
@@ -44,6 +49,8 @@ command, you wrap it in one of these two ways:
   `godep go install -v ./...`
 - When using a different command, set your `$GOPATH` using `godep path` as
   described below.
+
+Test files and testdata directories can be saved by adding `-t`.
 
 ## Additional Operations
 

--- a/godepfile.go
+++ b/godepfile.go
@@ -71,33 +71,35 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 		path = append(path, p.ImportPath)
 		path = append(path, p.Deps...)
 	}
-	var testImports []string
-	for _, p := range pkgs {
-		testImports = append(testImports, p.TestImports...)
-		testImports = append(testImports, p.XTestImports...)
-	}
-	ps, err := LoadPackages(testImports...)
-	if err != nil {
-		return err
-	}
-	for _, p := range ps {
-		if p.Standard {
-			continue
+	if saveT {
+		var testImports []string
+		for _, p := range pkgs {
+			testImports = append(testImports, p.TestImports...)
+			testImports = append(testImports, p.XTestImports...)
 		}
-		if p.Error.Err != "" {
-			log.Println(p.Error.Err)
-			err1 = errors.New("error loading packages")
-			continue
+		ps, err := LoadPackages(testImports...)
+		if err != nil {
+			return err
 		}
-		path = append(path, p.ImportPath)
-		path = append(path, p.Deps...)
+		for _, p := range ps {
+			if p.Standard {
+				continue
+			}
+			if p.Error.Err != "" {
+				log.Println(p.Error.Err)
+				err1 = errors.New("error loading packages")
+				continue
+			}
+			path = append(path, p.ImportPath)
+			path = append(path, p.Deps...)
+		}
 	}
 	for i, p := range path {
 		path[i] = unqualify(p)
 	}
 	sort.Strings(path)
 	path = uniq(path)
-	ps, err = LoadPackages(path...)
+	ps, err := LoadPackages(path...)
 	if err != nil {
 		return err
 	}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = 8
+const version = 9


### PR DESCRIPTION
Switch to not saving test files by default.

Add `-t` for those wishing to analyze and save test dependencies.

This is important for the usability of the vendor/ experiment where
`./...` also matches everything in `vendor/`.

You should test your dependencies, but it's not necessarily appropriate
to test them every time you want to test all of the code in your repository.

If you still want to save test files add `-t` to your save command(s).