### PR TITLE
Pass golint

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 var verbose bool // Verbose flag for commands that support it
 
-// A Command is an implementation of a godep command
+// Command is an implementation of a godep command
 // like godep save or godep go.
 type Command struct {
 	// Run runs the command.
@@ -35,6 +35,7 @@ type Command struct {
 	Flag flag.FlagSet
 }
 
+// Name returns the name of a command.
 func (c *Command) Name() string {
 	name := c.Usage
 	i := strings.Index(name, " ")
@@ -44,6 +45,7 @@ func (c *Command) Name() string {
 	return name
 }
 
+// UsageExit prints usage information and exits.
 func (c *Command) UsageExit() {
 	fmt.Fprintf(os.Stderr, "Usage: godep %s\n\n", c.Usage)
 	fmt.Fprintf(os.Stderr, "Run 'godep help %s' for help.\n", c.Name())

--- a/pkg.go
+++ b/pkg.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 )
 
+// Package represents a Go package.
 type Package struct {
 	Dir        string
 	Root       string

--- a/save.go
+++ b/save.go
@@ -443,6 +443,7 @@ func writeFile(name, body string) error {
 }
 
 const (
+	// Readme contains the README text.
 	Readme = `
 This directory tree is generated automatically by godep.
 

--- a/save_test.go
+++ b/save_test.go
@@ -1268,7 +1268,7 @@ func TestStripImportComment(t *testing.T) {
 
 func TestCopyWithoutImportCommentLongLines(t *testing.T) {
 	tmp := make([]byte, int(math.Pow(2, 16)))
-	for i, _ := range tmp {
+	for i := range tmp {
 		tmp[i] = 111 // fill it with "o"s
 	}
 

--- a/update.go
+++ b/update.go
@@ -142,6 +142,7 @@ func matchPattern(pattern string) func(name string) bool {
 	}
 }
 
+// LoadVCSAndUpdate loads and updates a set of dependencies.
 func LoadVCSAndUpdate(deps []Dependency) ([]Dependency, error) {
 	var err1 error
 	var paths []string

--- a/vcs.go
+++ b/vcs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tools/godep/Godeps/_workspace/src/golang.org/x/tools/go/vcs"
 )
 
+// VCS represents a version control system.
 type VCS struct {
 	vcs *vcs.Cmd
 
@@ -60,6 +61,7 @@ var cmd = map[*vcs.Cmd]*VCS{
 	vcsHg.vcs:  vcsHg,
 }
 
+// VCSFromDir returns a VCS value from a directory.
 func VCSFromDir(dir, srcRoot string) (*VCS, string, error) {
 	vcscmd, reporoot, err := vcs.FromDir(dir, srcRoot)
 	if err != nil {
@@ -72,6 +74,7 @@ func VCSFromDir(dir, srcRoot string) (*VCS, string, error) {
 	return vcsext, reporoot, nil
 }
 
+// VCSForImportPath returns a VCS value for an import path.
 func VCSForImportPath(importPath string) (*VCS, error) {
 	rr, err := vcs.RepoRootForImportPath(importPath, verbose)
 	if err != nil {


### PR DESCRIPTION
This branch makes the code pass ```golint```:

1. Comment all exported structs, constants and functions.
2. Remove an unnecessary blank identifier from an iteration.

All tests passing.