### PR TITLE
restore: download all in 1 pass, then restore

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -27,10 +27,19 @@ func runRestore(cmd *Command, args []string) {
 	}
 	hadError := false
 	for _, dep := range g.Deps {
-		err := restore(dep)
+		err := download(dep)
 		if err != nil {
 			log.Println("restore:", err)
 			hadError = true
+		}
+	}
+	if !hadError {
+		for _, dep := range g.Deps {
+			err := restore(dep)
+			if err != nil {
+				log.Println("restore:", err)
+				hadError = true
+			}
 		}
 	}
 	if hadError {
@@ -38,9 +47,8 @@ func runRestore(cmd *Command, args []string) {
 	}
 }
 
-// restore downloads the given dependency and checks out
-// the given revision.
-func restore(dep Dependency) error {
+// download downloads the given dependency.
+func download(dep Dependency) error {
 	// make sure pkg exists somewhere in GOPATH
 
 	args := []string{"get", "-d"}
@@ -48,10 +56,11 @@ func restore(dep Dependency) error {
 		args = append(args, "-v")
 	}
 
-	err := runIn(".", "go", append(args, dep.ImportPath)...)
-	if err != nil {
-		return err
-	}
+	return runIn(".", "go", append(args, dep.ImportPath)...)
+}
+
+// restore checks out the given revision.
+func restore(dep Dependency) error {
 	ps, err := LoadPackages(dep.ImportPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
Modify restore so that it downloads all the dependencies in one pass,
and then runs restore for each dependency in a second pass. We have seen
an issue where, depending on the order of the `go get` downloads,
sometimes one or more dependencies end up with the master branch as
HEAD, instead of the revision specified in Godeps.json. It appears that
`go get` resets the HEAD to master, even if the dependency has already
been downloaded and is pointing to a different ref.

Fixes #286 