### PR TITLE
Do a release to github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ script:
 before_install:
 - go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports
 before_deploy:
+- export TARGETS="linux darwin windows"
 - go get github.com/mitchellh/gox
-- gox -build-toolchain
-- gox -os "linux darwin windows"
+- gox -os "$TARGETS" -build-toolchain
+- gox -os "$TARGETS"
 deploy:
   skip_cleanup: true
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,5 @@ deploy:
     - godep_windows_386.exe
     - godep_windows_amd64.exe
   on:
-    all_branches: true
-    #tags: true
+    tags: true
     repo: tools/godep

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
 before_install:
 - go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports github.com/mitchellh/gox
 before_deploy:
+- gox -build-toolchain
 - gox -os "linux darwin windows"
 deploy:
   skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ deploy:
     - godep_windows_amd64.exe
   on:
     all_branches: true
-    tags: true
-    repo: tools/godep1p
+    #tags: true
+    repo: tools/godep

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ script:
 - go test -v -race
 - test -z "$(goimports -l .)"
 before_install:
-- go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports github.com/mitchellh/gox
+- go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports
 before_deploy:
+- go get github.com/mitchellh/gox
 - gox -build-toolchain
 - gox -os "linux darwin windows"
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,32 @@
 language: go
-
+sudo: false
 go: 1.4.2
-
 script:
-    # Godep's unit tests run git, and git complains
-    # if we don't set these config parameters.
-    # We put dummy values here because they don't matter.
-    - git config --global user.email "you@example.com"
-    - git config --global user.name "Your Name"
-
-    - test -z "$(go fmt)"
-    - go vet
-    - go test -v
-    - go test -v -race
-    - test -z "$(goimports -l .)"
-
+  # Godep's unit tests run git, and git complains
+  # if we don't set these config parameters.
+  # We put dummy values here because they don't matter.
+- git config --global user.email "you@example.com"
+- git config --global user.name "Your Name"
+- test -z "$(go fmt)"
+- go vet
+- go test -v
+- go test -v -race
+- test -z "$(goimports -l .)"
 before_install:
-    - go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports
+- go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports github.com/mitchellh/gox
+before_deploy:
+- gox -os "linux darwin windows"
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: Q1JP8LziaXMTxFmNXiyC1YhS9e4M4WnI6UDjRTMf6mm1LZeJyUFOCCtXnifL7RyCIR1hpjp6s8M1aWE+NpuweF96IZI3Uk4ASx5C8FePC4qvhsCdtJ2sLD2GTIrp9b0MS9/+ao20AIbpVDSaLaF9IjqXpMxMyM0P8P5coRTkwItlGxmQbVJW3YuiYcPa8UojwM4EyafO2CIoUKapW8lwb9KcimBJV8PfF/XZjPVhMkn2ABhh5Hqbn2zBJtvPYMMzi0CnY50JQF5LwN3vGTMpTsRP+lOLCNbOWfkl+2hgG7VpKrtx+cX62knOodpF457sIJ31KUzmeLUVBejTGb1zuVeTojuyi8Huo8YBIBCcN+p3Dqd+n2ZK45mIrheGiEJIkf/vI4MI6A01Nu/o+xU0IPsVfAL/xU5j5nntEGfFWVoclPrl9qcfqf74xdRcARzcCJVmdc8iw49DBDHJfnPa3zxzVz//00+Rz6mZXmhk+Npk/HLLNW59vmJIjP+8XOtPor7dST9HrS1a9AcnmIjNuw9yfbwK5769SDVxCKgqNwXW/Dy5F39aIH5AL4I4y9hCEeeT8ctvSJHGOyiB9MWU5jnt5tluPtz5opG51tFXnIYP/XaWpTfO+eJ6x55pbwT+n3LfRS5l1POM+jGAFF1MFWwc14RY7qynEIEzm4Wb/UE=
+  file:
+    - godep_darwin_amd64
+    - godep_linux_amd64
+    - godep_windows_386.exe
+    - godep_windows_amd64.exe
+  on:
+    all_branches: true
+    tags: true
+    repo: tools/godep1p

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ script:
 before_install:
 - go get golang.org/x/tools/cmd/vet golang.org/x/tools/cmd/goimports
 before_deploy:
-- export TARGETS="linux darwin windows"
+- export OS_TARGETS="linux darwin windows"
+- export ARCH_TARGETS="386 amd64"
 - go get github.com/mitchellh/gox
-- gox -os "$TARGETS" -build-toolchain
-- gox -os "$TARGETS"
+- gox -os "$OS_TARGETS" -arch="$ARCH_TARGETS" -build-toolchain
+- gox -os "$OS_TARGETS" -arch="$ARCH_TARGETS"
 deploy:
   skip_cleanup: true
   provider: releases


### PR DESCRIPTION
For those that want officially created binaries instead of requiring `go
get` as the only install method.

I would remove the `all_branches` flag if merged so that it only works
off master, but I need it now for testing.

Fixes #110 (or at least part of it, I don't intent to cover the hash / security parts).