### PR TITLE
save: Improve error message when trying to save a conflicting revision.

### DIFF
--- a/save.go
+++ b/save.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -186,12 +187,14 @@ func save(pkgs []string) error {
 
 type revError struct {
 	ImportPath string
+	HavePath   string
 	HaveRev    string
 	WantRev    string
 }
 
 func (v *revError) Error() string {
-	return v.ImportPath + ": revision is " + v.HaveRev + ", want " + v.WantRev
+	return fmt.Sprintf("cannot save %s at revision %s: already have %s at revision %s.\n"+
+		"Run `godep update %s' first.", v.ImportPath, v.WantRev, v.HavePath, v.HaveRev, v.HavePath)
 }
 
 // carryVersions copies Rev and Comment from a to b for
@@ -225,11 +228,11 @@ func carryVersion(a *Godeps, db *Dependency) error {
 		switch {
 		case strings.HasPrefix(db.ImportPath, da.ImportPath+"/"):
 			if da.Rev != db.Rev {
-				return &revError{db.ImportPath, db.Rev, da.Rev}
+				return &revError{db.ImportPath, da.ImportPath, db.Rev, da.Rev}
 			}
 		case strings.HasPrefix(da.ImportPath, db.root+"/"):
 			if da.Rev != db.Rev {
-				return &revError{db.ImportPath, db.Rev, da.Rev}
+				return &revError{db.ImportPath, db.root, db.Rev, da.Rev}
 			}
 		}
 	}


### PR DESCRIPTION
When a sub-path is saved, godep requires that all subpaths originating
from the same repo be pinned at the same revision.  When one attempts to
save a new subpath at a different revision, godep produces a confusing
error message, which this commits improves.

In my case I had golang.org/x/net already saved and as a result of
pulling new gRPC code, `godep save ./...` was trying to save the new
path golang.org/x/net/http2, and failing in a puzzling way:

> $ godep save ./...
> godep: golang.org/x/net/http2: revision is b846920a172af75fe52c1400ae6094307be83b8a, want 7654728e381988afd88e58cabfd6363a5ea91810

Now:

> $ godep save ./...
> godep: cannot save golang.org/x/net/http2 at revision 7654728e381988afd88e58cabfd6363a5ea91810: already have golang.org/x/net at revision b846920a172af75fe52c1400ae6094307be83b8a.
> Update golang.org/x/net first.