### PR TITLE
Check for git modifications only in subtrees

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -40,7 +40,7 @@ var vcsGit = &VCS{
 
 	IdentifyCmd: "rev-parse HEAD",
 	DescribeCmd: "describe --tags",
-	DiffCmd:     "diff {rev}",
+	DiffCmd:     "diff {rev} .",
 	ListCmd:     "ls-files --full-name",
 	RootCmd:     "rev-parse --show-toplevel",
 

--- a/vcs.go
+++ b/vcs.go
@@ -52,7 +52,7 @@ var vcsHg = &VCS{
 
 	IdentifyCmd: "identify --id --debug",
 	DescribeCmd: "log -r . --template {latesttag}-{latesttagdistance}",
-	DiffCmd:     "diff -r {rev}",
+	DiffCmd:     "diff -r {rev} .",
 	ListCmd:     "status --all --no-status",
 	RootCmd:     "root",
 


### PR DESCRIPTION
Currently, `git diff {rev}` is invoked for checking for a dirty working copy. This produces a diff of the whole repository, which might include modifications in files that are outside of the package being imported. For instance, consider `golang.org/x/crypto`, which is a single git repository including many packages: if the user code imports `golang.org/x/crypto/ssh`, a call to `godep save` will fail if there is a file modified in `golang.org/x/crypto/openpgp`, which has nothing to do with it (it just happens to be within the same git repository).

The proposed modification limits `git diff` to show only differences in the package directory and its subtree; while this is technically still too much (`godep` should only care about modification in the packages being imported, not subpackages), it is consistent with the rest of code that vendors the whole subtree, so it makes sense to check all of it.