### PR TITLE
Adds a -i flag to override the VCS dirty state check for development purposes.

### DIFF
--- a/save.go
+++ b/save.go
@@ -17,7 +17,7 @@ import (
 )
 
 var cmdSave = &Command{
-	Usage: "save [-r] [-v] [-t] [packages]",
+	Usage: "save [-r] [-v] [-t] [-i] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 
@@ -55,6 +55,9 @@ If -v is given, verbose output is enabled.
 If -t is given, test files (*_test.go files + testdata directories) are
 also saved.
 
+If -i is given, VCS dirty state is ignored.  This facilitates simultaneous
+package development and should never be used with production builds.
+
 For more about specifying packages, see 'go help packages'.
 `,
 	Run: runSave,
@@ -68,6 +71,7 @@ func init() {
 	cmdSave.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
 	cmdSave.Flag.BoolVar(&saveR, "r", false, "rewrite import paths")
 	cmdSave.Flag.BoolVar(&saveT, "t", false, "save test files")
+	cmdSave.Flag.BoolVar(&ignoreDirtyState, "i", false, "ignore dirty ")
 }
 
 func runSave(cmd *Command, args []string) {

--- a/vcs.go
+++ b/vcs.go
@@ -25,6 +25,9 @@ type VCS struct {
 	ExistsCmd string
 }
 
+// ignoreDirtyState will override isDirty if set to true.
+var ignoreDirtyState = false
+
 var vcsBzr = &VCS{
 	vcs: vcs.ByCmd("bzr"),
 
@@ -110,6 +113,11 @@ func (v *VCS) describe(dir, rev string) string {
 }
 
 func (v *VCS) isDirty(dir, rev string) bool {
+
+	if ignoreDirtyState {
+		return false
+	}
+
 	out, err := v.runOutput(dir, v.DiffCmd, "rev", rev)
 	return err != nil || len(out) != 0
 }


### PR DESCRIPTION
Our company has multiple packages in a single git repo, and we hit a roadblock with godep when we pulled some code out of one pakage into an imported package in an adjacent directory.  The zealous `isDirty` check prevents us from running `godep save` when we are working with changes that affect multiple packages.

Note that our `godep save` issue is similar to rasky's issue from his pull request (rasky/godep@73ef0c2cddab0bb26773e5b387b2b446732dd552) but I believe @rasky is dealing with unrelated packages, whereas ours _are_ related.