### PR TITLE
Do not use --debug to find hg identify revision

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v23 2015/11/05
+
+* Do not use --debug to find full revision name for mercurial repositories
+
 # v22 2016/11/14
 
 * s/GOVENDOREXPERIMENT/GO15VENDOREXPERIMENT :-(

--- a/vcs.go
+++ b/vcs.go
@@ -50,7 +50,7 @@ var vcsGit = &VCS{
 var vcsHg = &VCS{
 	vcs: vcs.ByCmd("hg"),
 
-	IdentifyCmd: "identify --id --debug",
+	IdentifyCmd: "parents --template '{node}'",
 	DescribeCmd: "log -r . --template {latesttag}-{latesttagdistance}",
 	DiffCmd:     "diff -r {rev}",
 	ListCmd:     "status --all --no-status",

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const version = 22
+const version = 23


### PR DESCRIPTION
When an hg extension uses a post-identify hook it also outputs a debug statement notifying that the hook has executed.  godep uses 'identify --id --debug' to get the current full revision identifier.  The --debug causes the post-identify hook debug statement to be output which godep sees as being a 'dirty working tree' and fails