### PR TITLE
run command once during restore -v

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -29,7 +29,7 @@ func runRestore(cmd *Command, args []string) {
 	for _, dep := range g.Deps {
 		err := download(dep)
 		if err != nil {
-			log.Println("restore:", err)
+			log.Println("restore, during download dep:", err)
 			hadError = true
 		}
 	}
@@ -37,7 +37,7 @@ func runRestore(cmd *Command, args []string) {
 		for _, dep := range g.Deps {
 			err := restore(dep)
 			if err != nil {
-				log.Println("restore:", err)
+				log.Println("restore, during restore dep:", err)
 				hadError = true
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 )
 
@@ -12,18 +11,13 @@ import (
 // from the current process.
 func runIn(dir, name string, args ...string) error {
 	c := exec.Command(name, args...)
+	c.Dir = dir
+	output, err := c.CombinedOutput()
 
 	if verbose {
-		output, err := c.CombinedOutput()
-		fmt.Printf("execute %+v", c)
-		fmt.Printf(string(output))
-		if err != nil {
-			return fmt.Errorf("Error is %v", err)
-		}
+		fmt.Printf("execute: %+v\n", c)
+		fmt.Printf(" output: %s\n", output)
 	}
 
-	c.Dir = dir
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	return c.Run()
+	return err
 }


### PR DESCRIPTION
Running `godep restore -v` would always error out because the CombinedOutput command did a Run under the hood, and the second Run at the end of restore would error out.
    
Along the way, I added some more context (and a couple of newlines) to the restore error prints to figure out what was going on.