### PR TITLE
Fix license vendoring

### DIFF
--- a/save.go
+++ b/save.go
@@ -316,7 +316,7 @@ func copySrc(dir string, deps []Dependency) error {
 		w = fs.Walk(rootdir)
 		for w.Step() {
 			fname := filepath.Base(w.Path())
-			if IsLegalFile(fname) {
+			if IsLegalFile(fname) && !strings.Contains(w.Path(), sep) {
 				err = copyPkgFile(vf, dir, srcdir, w)
 				if err != nil {
 					log.Println(err)

--- a/save_test.go
+++ b/save_test.go
@@ -1093,6 +1093,8 @@ func TestSave(t *testing.T) {
 						{"LICENSE", pkg("D"), nil},
 						{"P/main.go", pkg("P"), nil},
 						{"P/LICENSE", pkg("P"), nil},
+						{"Godeps/_workspace/src/E/LICENSE", pkg("E"), nil},
+						{"Godeps/_workspace/src/E/main.go", pkg("E"), nil},
 						{"Q/main.go", pkg("Q"), nil},
 						{"+git", "D1", nil},
 					},
@@ -1104,6 +1106,7 @@ func TestSave(t *testing.T) {
 				{"C/Godeps/_workspace/src/D/P/main.go", pkg("P"), nil},
 				{"C/Godeps/_workspace/src/D/P/LICENSE", pkg("P"), nil},
 				{"C/Godeps/_workspace/src/D/Q/main.go", pkg("Q"), nil},
+				{"C/Godeps/_workspace/src/D/Godeps/_workspace/src/E/LICENSE", "(absent)", nil},
 			},
 			wdep: Godeps{
 				ImportPath: "C",


### PR DESCRIPTION
This resolves an issue I was seeing where Godep would vendor LICENSE files dependencies dependencies. 

I saw this specifically when importing a package that depended on the AWS SDK which depends on go-ini which contains a LICENSE file. I would then get an error from `go build` like `no buildable Go source files in my-project/vendor/github.com/aws/aws-sdk-go/vendor/github.com/vaughan0/go-ini` and `vendor/github.com/aws/aws-sdk-go/vendor/github.com/vaughan0/go-ini` only contains a LICENSE file. 

Added a test case that confirms this fix.