### PR TITLE
Fixed symlink handling

### DIFF
--- a/save.go
+++ b/save.go
@@ -267,11 +267,20 @@ func removeSrc(srcdir string, deps []Dependency) error {
 }
 
 func copySrc(dir string, deps []Dependency) error {
+	var err error
 	// mapping to see if we visited a parent directory already
 	visited := make(map[string]bool)
 	ok := true
 	for _, dep := range deps {
 		srcdir := filepath.Join(dep.ws, "src")
+		srcdir, err = filepath.EvalSymlinks(srcdir)
+		if err != nil {
+			return err
+		}
+		dep.dir, err = filepath.EvalSymlinks(dep.dir)
+		if err != nil {
+			return err
+		}
 		rel, err := filepath.Rel(srcdir, dep.dir)
 		if err != nil { // this should never happen
 			return err


### PR DESCRIPTION
After upgrade from Godep v7 to v28, `godep save ./...` would no longer pull in all of my dependencies. After some digging and turning on verbose mode, I was able to see many messages like:

```
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/dce.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/doc.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/hash.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/json.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/node.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/sql.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/time.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/util.go
godep: save: skipping untracked file: /Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src/github.com/pborman/uuid/uuid.go
```

The problem is that on my setup, `/Users/michaelrobinson/.gvm/pkgsets/go1.5.1/global/src` is a symlink. So Godep was comparing the non-evaluated path to its internal VCS evaluated path and concluding that the files weren't tracked. I was able to solve this by evaluating symlinks in the input `srcdir` and `dep.dir`. 

Here is a screen capture of my GOPATH setup, including the symlinks. I do it this way so that all my versions of Go point to the same set of third-party Go code, and the second part of my GOPATH is my first-party Go code.
![screen-capture](https://cloud.githubusercontent.com/assets/11935429/11097446/bea86a44-885c-11e5-80e1-e46a75c8996f.png)