### PR TITLE
fix isDirty command

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -40,7 +40,7 @@ var vcsGit = &VCS{
 
 	IdentifyCmd: "rev-parse HEAD",
 	DescribeCmd: "describe --tags",
-	DiffCmd:     "diff {rev}",
+	DiffCmd:     "diff {rev} --dirstat .",
 	ListCmd:     "ls-files --full-name",
 	RootCmd:     "rev-parse --show-toplevel",
 


### PR DESCRIPTION
It's pretty conventional in Go land to have a repository that has multiple commands built into it. For example, see: https://github.com/kubernetes/kubernetes/tree/master/cmd

Sometimes, you might want to vendor these different commands separately, which would lead you wanting to have a vendor directory in each folder. Right now, godep doesn't support this because it's
"isDirty" check is overzealous. Instead of checking just the package that it takes as an argument, it checks the _whole_ repository that that package is in.

This commit changes it for git (I don't use other VCS and don't know if they work correctly or are also broken) so that it only checks the package that it's trying to vendor instead of the whole repository.

Fixes #303 and #305.