### PR TITLE
Get Test Package Dependencies Option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v30 2015/11/25
+
+* Add `-t` flag to the `godep get` command.
+
 # v29 2015/11/17
 
 * Temp work around to fix issue with LICENSE files.

--- a/get.go
+++ b/get.go
@@ -7,7 +7,7 @@ import (
 )
 
 var cmdGet = &Command{
-	Usage: "get [-v] [packages]",
+	Usage: "get [-v] [-t] [packages]",
 	Short: "download and install packages with specified dependencies",
 	Long: `
 Get downloads to GOPATH the packages named by the import paths, and installs
@@ -18,13 +18,18 @@ as if by go get.
 
 If -verbose is given, verbose output is enabled.
 
+If -t is given, dependencies of test files are also downloaded and installed.
+
 For more about specifying packages, see 'go help packages'.
 `,
 	Run: runGet,
 }
 
+var getT bool
+
 func init() {
 	cmdGet.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
+	cmdGet.Flag.BoolVar(&getT, "t", false, "get test dependencies")
 }
 
 func runGet(cmd *Command, args []string) {
@@ -35,6 +40,10 @@ func runGet(cmd *Command, args []string) {
 	cmdArgs := []interface{}{"get", "-d"}
 	if verbose {
 		cmdArgs = append(cmdArgs, "-v")
+	}
+
+	if getT {
+		cmdArgs = append(cmdArgs, "-t")
 	}
 
 	err := command("go", append(cmdArgs, args)...).Run()

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 29
+const version = 30
 
 var cmdVersion = &Command{
 	Usage: "version",


### PR DESCRIPTION
This feature adds a `-t` flag to the `godep get` command to download and install test package dependencies. This is similar to the `-t` flag in the `go get` command.

I wasn't sure how to handle the version change so I simply incremented the version number. Please let me know if this should be done differently.