### PR TITLE
In restore errors, mention which package had the problem.

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -29,7 +29,7 @@ func runRestore(cmd *Command, args []string) {
 	for _, dep := range g.Deps {
 		err := download(dep)
 		if err != nil {
-			log.Println("restore, during download dep:", err)
+			log.Printf("restore, during download dep %q: %v\n", dep.ImportPath, err)
 			hadError = true
 		}
 	}
@@ -37,7 +37,7 @@ func runRestore(cmd *Command, args []string) {
 		for _, dep := range g.Deps {
 			err := restore(dep)
 			if err != nil {
-				log.Println("restore, during restore dep:", err)
+				log.Printf("restore, during restore dep %q: %v\n", dep.ImportPath, err)
 				hadError = true
 			}
 		}


### PR DESCRIPTION
This improves the situation when the user runs `godep restore` and sees a few instances of "restore, during download dep" errors. Previously, it was not mentioned which packages failed to download. Turning on -v verbose mode was not a good solution since it prints too much other information for successfully processed packages.