### PR TITLE
Vendor applications safely

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,29 @@ command, you wrap it in one of these two ways:
 
 Test files and testdata directories can be saved by adding `-t`.
 
+It is also possible to vendor "main" packages, but not through a go source file
+in the project. Instead, create a file named "appVendor" and add the desired
+packages there, one in each line. The file may look like as follows:
+
+```
+// You can use double slash to write a comment
+# But you can also use hash for the same purpose
+
+github.com/fizz/buzz
+github.com/foo/bar
+
+
+// Empty lines are also allowed
+github.com/one/two // Comments after package are allowed
+github.com/three/four # Same with hash comments
+
+// Vendor in the quux app, we build it ourselves and use it in tests
+github.com/a/b/apps/quux
+```
+
+All the packages in "appVendor" file together with their dependencies will be
+added to the Godeps file.
+
 ## Additional Operations
 
 ### Restore

--- a/appvendor_test.go
+++ b/appvendor_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAppPkgs(t *testing.T) {
+	testAppVendorContents := `
+// some slash comment
+# some hash comment
+
+github.com/tools/godep
+github.com/golang/go // package with a slash comment
+github.com/golang/tools # package with hash comment
+
+`
+	expectedPkgs := []string{
+		"github.com/tools/godep",
+		"github.com/golang/go",
+		"github.com/golang/tools",
+	}
+	r := strings.NewReader(testAppVendorContents)
+	pkgs, err := getAppPkgsFromReader(r)
+	if err != nil {
+		t.Errorf("Failed to parse %q: %v", testAppVendorContents, err)
+	}
+	if !reflect.DeepEqual(pkgs, expectedPkgs) {
+		t.Errorf("App pkgs = %v want %v", pkgs, expectedPkgs)
+	}
+}

--- a/appvendorfile.go
+++ b/appvendorfile.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+)
+
+var (
+	appVendorFile = "appVendor"
+)
+
+func getAppPkgsFromReader(r io.Reader) ([]string, error) {
+	s := bufio.NewScanner(r)
+	var pkgs []string
+	for s.Scan() {
+		l := s.Text()
+		l = strings.SplitN(l, "#", 2)[0]
+		l = strings.SplitN(l, "//", 2)[0]
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		pkgs = append(pkgs, l)
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return pkgs, nil
+}
+
+func getAppPkgs() ([]string, error) {
+	f, err := os.Open(appVendorFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	return getAppPkgsFromReader(f)
+}

--- a/godepfile.go
+++ b/godepfile.go
@@ -72,7 +72,11 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 		testImports = append(testImports, p.TestImports...)
 		testImports = append(testImports, p.XTestImports...)
 	}
-	ps, err := LoadPackages(testImports...)
+	appPkgs, err := getAppPkgs()
+	if err != nil {
+		return err
+	}
+	ps, err := LoadPackages(append(testImports, appPkgs...)...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For go 1.4, adding a dummy go file with some import clauses importing
"main" packages was enough for godep to vendor them. With go 1.5 it is
not working anymore, because go will bail out when loading a package
with this dummy go file with an error 'import 'some/main/package' is a
program, not an importable package'.

This introduces reading the "appVendor" file, which is basically a
list of main packages to import. It is not a go source file, so it
sidesteps the issue with the new go.

The reason to add this is that the project may want to use some
application from specific revision during building or testing. git
submodules allow that, but the problem can arise when the project
disappears. "go get" does not allow getting a specific revision.

The above is a commit message, so a small addition follows. The specific use case is in [coreos/rkt](https://github.com/coreos/rkt), where we have [a dummy.go file](https://github.com/coreos/rkt/blob/master/stage1/dummy.go) importing some "main" packages which are built by our build system. This worked fine when we were using go 1.4, but it stopped working with go 1.5.

I'm not sure about two points in this PR:

- The location and filename of the file, currently we expect it to be in project's root (like `Godeps` directory) and have a name `appVendor`.
  - I suppose it would be better if it was inside `Godeps` directory, but:
    - It would require the `godep` user to create the directory.
    - It would require `godep` to recreate the file as whole `Godeps` directory gets removed during `save` command (right?). Not a problem per se, just more code to be written.
  - The `appVendor` name is… meh. But naming is hard.
  - I decided against another JSON file, because we might want to have comments there.
- Should we allow both styles of comments (script like `#` and C-or-go-like `//`)?