### PR TITLE
Add -a flag to vendor regardless of build tags

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"go/build"
+	"go/parser"
+	"go/token"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
 )
 
 // Package represents a Go package.
@@ -62,6 +69,135 @@ func LoadPackages(name ...string) (a []*Package, err error) {
 	err = cmd.Wait()
 	if err != nil {
 		return nil, err
+	}
+	return a, nil
+}
+
+func walkExt(targetDir, ext string) (map[string]struct{}, error) {
+	rmap := make(map[string]struct{})
+	visit := func(path string, f os.FileInfo, err error) error {
+		if f != nil {
+			if !f.IsDir() {
+				if filepath.Ext(path) == ext {
+					if !filepath.HasPrefix(path, ".") && !strings.Contains(path, "/.") {
+						wd, err := os.Getwd()
+						if err != nil {
+							return err
+						}
+						thepath := filepath.Join(wd, strings.Replace(path, wd, "", -1))
+						rmap[thepath] = struct{}{}
+					}
+				}
+			}
+		}
+		return nil
+	}
+	err := filepath.Walk(targetDir, visit)
+	if err != nil {
+		return nil, err
+	}
+	return rmap, nil
+}
+
+// https://github.com/golang/go/blob/master/src/go/build/syslist.go#L7
+const goosList = "android darwin dragonfly freebsd linux nacl netbsd openbsd plan9 solaris windows "
+const goarchList = "386 amd64 amd64p32 arm armbe arm64 arm64be ppc64 ppc64le mips mipsle mips64 mips64le mips64p32 mips64p32le ppc s390 s390x sparc sparc64 "
+const appengineList = "appengine appenginevm"
+
+func importDeps(dir string) (map[string]struct{}, error) {
+	wm, err := walkExt(dir, ".go")
+	if err != nil {
+		return nil, err
+	}
+	fSize := len(wm)
+	if fSize == 0 {
+		return nil, nil
+	}
+	var mu sync.Mutex // guards the map
+	fmap := make(map[string]struct{})
+	done, errCh := make(chan struct{}), make(chan error)
+	for fpath := range wm {
+		go func(fpath string) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, fpath, nil, parser.ImportsOnly|parser.ParseComments)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			ignore := false
+			for _, cc := range f.Comments {
+				for _, v := range cc.List {
+					if strings.HasPrefix(v.Text, "// +build ignore") {
+						ignore = true
+						break
+					}
+					if strings.HasPrefix(v.Text, "// +build") {
+						p := strings.Replace(v.Text, "// +build ", "", -1)
+						if !strings.Contains(goosList, p) && !strings.Contains(goarchList, p) && !strings.Contains(appengineList, p) {
+							ignore = true
+							break
+						}
+					}
+				}
+				if ignore {
+					break
+				}
+			}
+			if !ignore {
+				for _, elem := range f.Imports {
+					pv := strings.TrimSpace(strings.Replace(elem.Path.Value, `"`, "", -1))
+					if pv == "C" || build.IsLocalImport(pv) || strings.HasPrefix(pv, ".") {
+						continue
+					}
+					mu.Lock()
+					fmap[pv] = struct{}{}
+					mu.Unlock()
+				}
+			}
+			done <- struct{}{}
+		}(fpath)
+	}
+	i := 0
+	for {
+		select {
+		case e := <-errCh:
+			return nil, e
+		case <-done:
+			i++
+			if i == fSize {
+				close(done)
+				return fmap, nil
+			}
+		}
+	}
+}
+
+func LoadPackagesAll(name ...string) (a []*Package, err error) {
+	a, err = LoadPackages(name...)
+	if err != nil {
+		return nil, err
+	}
+	for _, v := range a {
+		// get dependencies from all Go files
+		dm, err := importDeps(v.Dir)
+		if err != nil {
+			return nil, err
+		}
+		nDeps := make(map[string]struct{})
+		for _, v := range v.Deps {
+			nDeps[v] = struct{}{}
+		}
+		for k := range dm {
+			nDeps[k] = struct{}{}
+		}
+		ds := []string{}
+		for k := range nDeps {
+			ds = append(ds, k)
+		}
+		sort.Strings(ds)
+		v.Deps = ds
+		v.GoFiles = append(v.GoFiles, v.IgnoredGoFiles...)
+		v.IgnoredGoFiles = []string{}
 	}
 	return a, nil
 }

--- a/save_test.go
+++ b/save_test.go
@@ -1149,7 +1149,7 @@ func TestSave(t *testing.T) {
 		}
 		saveR = test.flagR
 		saveT = test.flagT
-		err = save(test.args)
+		err = save(false, test.args)
 		if g := err != nil; g != test.werr {
 			if err != nil {
 				t.Log(err)


### PR DESCRIPTION
This adds a flag `-a` when people need to vendor everything regardless of build
tags. This fixes https://github.com/tools/godep/issues/271.