### PR TITLE
Dependencies sorting

### DIFF
--- a/dep.go
+++ b/dep.go
@@ -81,3 +81,21 @@ func goVersion() (string, error) {
 	}
 	return p[2], nil
 }
+
+// dependencySlice - slice of Dependency
+type dependencySlice []Dependency
+
+// Len implements sort Len interface
+func (this dependencySlice) Len() int {
+	return len(this)
+}
+
+// Less implements sort Less interface
+func (this dependencySlice) Less(i, j int) bool {
+	return this[i].ImportPath < this[j].ImportPath
+}
+
+// Less implements sort Swap interface
+func (this dependencySlice) Swap(i, j int) {
+	this[i], this[j] = this[j], this[i]
+}

--- a/godepfile.go
+++ b/godepfile.go
@@ -163,6 +163,10 @@ func (g *Godeps) save() (int64, error) {
 }
 
 func (g *Godeps) writeTo(w io.Writer) (int64, error) {
+	//sort Dependencies
+	sort.Strings(g.Packages)
+	sort.Sort(dependencySlice(g.Deps))
+
 	b, err := json.MarshalIndent(g, "", "\t")
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Hello!
As i can see godep now has problem that after saving dependencies after few commits, you can get very different file .json. What creates great confusion when merge, especially in large projects: a big diff of .json file is difficult to understand and difficult to figure out whether developer change a lot of dependencies, or only one or two, but godep changed their order when saving a file.
I think that the addition of sorting dependencies would be useful.
