### PR TITLE
EvalSymlinks in Contains() check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-# v31 2015/12/2
+# v32 2015/12/02
+
+* Eval Symlinks in Contains() check.
+
+# v31 2015/12/02
 
 * In restore, mention which package had the problem -- @shurcool
 

--- a/vcs.go
+++ b/vcs.go
@@ -128,6 +128,15 @@ func (vf vcsFiles) Contains(path string) bool {
 		if strings.EqualFold(f, path) {
 			return true
 		}
+		// git's root command (maybe other vcs as well) resolve symlinks, so try that too
+		// FIXME: rev-parse --show-cdup + extra logic will fix this for git but also need to validate the other vcs commands. This is maybe temporary.
+		p, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return false
+		}
+		if strings.EqualFold(f, p) {
+			return true
+		}
 	}
 
 	// No matches by either method

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 31
+const version = 32
 
 var cmdVersion = &Command{
 	Usage: "version",


### PR DESCRIPTION
git's root command (maybe others vcs as well) resolve symlinks, so try
that too.

PS: In git's case we can possible use rev-parse --show-cdup + extra
logic to find the root of the repo instead. Need to figure out what
other vcs root commands do as well.

Fixes #339