### PR TITLE
Record / Update only the major go version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# v39 2015/12/16
+
+* Record only the major go version (ex. go1.5) instead of the complete string.
+
 # v38 2015/12/16
 
 * Replace `go get`, further fix up restore error handling/reporting.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/tools/godep",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.5",
 	"Deps": [
 		{
 			"ImportPath": "github.com/kr/fs",

--- a/dep.go
+++ b/dep.go
@@ -68,8 +68,17 @@ func uniq(a []string) []string {
 	return a[:i]
 }
 
-// goVersion returns the version string of the Go compiler
-// currently installed, e.g. "go1.1rc3".
+// trimGoVersion and return the major version
+func trimGoVersion(version string) (string, error) {
+	p := strings.Split(version, ".")
+	if len(p) < 2 {
+		return "", fmt.Errorf("Error determing major go version from: %q", version)
+	}
+	return p[0] + "." + p[1], nil
+}
+
+// goVersion returns the major version string of the Go compiler
+// currently installed, e.g. "go1.5".
 func goVersion() (string, error) {
 	// Godep might have been compiled with a different
 	// version, so we can't just use runtime.Version here.
@@ -79,9 +88,9 @@ func goVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	p := strings.Split(string(out), " ")
-	if len(p) < 3 {
+	gv := strings.Split(string(out), " ")
+	if len(gv) < 3 {
 		return "", fmt.Errorf("Error splitting output of `go version`: Expected 3 or more elements, but there are < 3: %q", string(out))
 	}
-	return p[2], nil
+	return trimGoVersion(gv[2])
 }

--- a/diff.go
+++ b/diff.go
@@ -33,14 +33,9 @@ func runDiff(cmd *Command, args []string) {
 		log.Fatalln(err)
 	}
 
-	ver, err := goVersion()
-	if err != nil {
-		log.Fatalln(err)
-	}
-
 	gnew := &Godeps{
 		ImportPath: dot[0].ImportPath,
-		GoVersion:  ver,
+		GoVersion:  gold.GoVersion,
 	}
 
 	err = gnew.fill(dot, dot[0].ImportPath)

--- a/update.go
+++ b/update.go
@@ -4,6 +4,7 @@ import (
 	"go/parser"
 	"go/token"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -12,30 +13,66 @@ import (
 
 var cmdUpdate = &Command{
 	Name:  "update",
-	Args:  "[packages]",
-	Short: "use different revision of selected packages",
+	Args:  "[-goversion] [packages]",
+	Short: "update selected packages or the go version",
 	Long: `
 Update changes the named dependency packages to use the
 revision of each currently installed in GOPATH. New code will
-be copied into Godeps and the new revision will be written to
-the manifest.
+be copied into the Godeps workspace or vendor folder and the 
+new revision will be written to the manifest.
 
-For more about specifying packages, see 'go help packages'.
+If -goversion is specified, update the recorded go version. 
 
 If -d is given, debug output is enabled (you probably don't want this).
+
+For more about specifying packages, see 'go help packages'.
 `,
 	Run: runUpdate,
 }
+var (
+	updateGoVer bool
+)
 
 func init() {
 	cmdUpdate.Flag.BoolVar(&saveT, "t", false, "save test files during update")
+	cmdUpdate.Flag.BoolVar(&updateGoVer, "goversion", false, "update the recorded go version")
 }
 
 func runUpdate(cmd *Command, args []string) {
-	err := update(args)
+	if updateGoVer {
+		updateGoVersion()
+	}
+	if len(args) > 0 {
+		err := update(args)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}
+
+func updateGoVersion() {
+	gold, err := loadDefaultGodepsFile()
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Fatalln(err)
+		}
+	}
+	cv, err := goVersion()
 	if err != nil {
 		log.Fatalln(err)
 	}
+
+	gv := gold.GoVersion
+	gold.GoVersion = cv
+	_, err = gold.save()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if gv != cv {
+		log.Println("Updated major go version to", cv)
+	}
+
 }
 
 func update(args []string) error {

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 38
+const version = 39
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
The idea is that we shouldn't care about the minor revision of Go.

/cc @kr, @neurogeek 