### PR TITLE
Just warn about multiple packages

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -43,10 +43,12 @@ func LoadPackages(names ...string) (a []*Package, err error) {
 	}
 	for _, i := range importPaths(names) {
 		p, err := listPackage(i)
-		if err != nil {
-			return nil, err
+		if p != nil {
+			a = append(a, p)
 		}
-		a = append(a, p)
+		if err != nil {
+			return a, err
+		}
 	}
 	return a, nil
 }

--- a/pkg.go
+++ b/pkg.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"go/build"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -47,7 +49,11 @@ func LoadPackages(names ...string) (a []*Package, err error) {
 			a = append(a, p)
 		}
 		if err != nil {
-			return a, err
+			if _, ok := err.(*build.MultiplePackageError); ok {
+				log.Printf("warning: %v\n", err)
+			} else {
+				return a, err
+			}
 		}
 	}
 	return a, nil

--- a/save.go
+++ b/save.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"log"
@@ -87,7 +88,11 @@ func runSave(cmd *Command, args []string) {
 func dotPackage() (*Package, error) {
 	p, err := LoadPackages(".")
 	if err != nil {
-		return nil, err
+		// We only want an import path, really and it is
+		// provided even if there are no buildable Go sources
+		if _, ok := err.(*build.NoGoError); !ok {
+			return nil, err
+		}
 	}
 	if len(p) > 1 {
 		panic("Impossible number of packages")

--- a/save_test.go
+++ b/save_test.go
@@ -1174,6 +1174,40 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // toplevel package has no buildable Go sources
+			cwd:  "C",
+			args: []string{"./..."},
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"S/lib.go", pkg("S", "D"), nil},
+						{"M/main.go", pkg("main", "C/S"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"lib.go", pkg("D"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/S/lib.go", pkg("S", "D"), nil},
+				{"C/M/main.go", pkg("main", "C/S"), nil},
+				{"C/Godeps/_workspace/src/D/lib.go", pkg("D"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()


### PR DESCRIPTION
There are many projects outside that have some helper binaries with a
"// +build ignore" clause and "main" package in a directory, where the
rest of files have some other package name.

So far I found [cznic/ql](https://github.com/cznic/ql/pull/114), [coreos/rkt](https://github.com/coreos/rkt/pull/1848) and golang.org/x/net/html/atom (found packages atom (atom.go) and main (gen.go) in /home/kv/projects/coreos/GOPATH/src/golang.org/x/net/html/atom)

This depends on #346, as both modify the code around the same place.