### PR TITLE
stow away helper files

### DIFF
--- a/pkg.go
+++ b/pkg.go
@@ -43,10 +43,12 @@ func LoadPackages(names ...string) (a []*Package, err error) {
 	}
 	for _, i := range importPaths(names) {
 		p, err := listPackage(i)
-		if err != nil {
-			return nil, err
+		if p != nil {
+			a = append(a, p)
 		}
-		a = append(a, p)
+		if err != nil {
+			return a, err
+		}
 	}
 	return a, nil
 }

--- a/pkg.go
+++ b/pkg.go
@@ -42,7 +42,8 @@ func LoadPackages(names ...string) (a []*Package, err error) {
 		return nil, nil
 	}
 	for _, i := range importPaths(names) {
-		p, err := listPackage(i)
+		p, stowed, err := listPackage(i)
+		defer bringTheFilesBackToNormal(stowed)
 		if p != nil {
 			a = append(a, p)
 		}

--- a/save.go
+++ b/save.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"go/build"
 	"io"
 	"io/ioutil"
 	"log"
@@ -87,7 +88,11 @@ func runSave(cmd *Command, args []string) {
 func dotPackage() (*Package, error) {
 	p, err := LoadPackages(".")
 	if err != nil {
-		return nil, err
+		// We only want an import path, really and it is
+		// provided even if there are no buildable Go sources
+		if _, ok := err.(*build.NoGoError); !ok {
+			return nil, err
+		}
 	}
 	if len(p) > 1 {
 		panic("Impossible number of packages")

--- a/save_test.go
+++ b/save_test.go
@@ -1174,6 +1174,40 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // toplevel package has no buildable Go sources
+			cwd:  "C",
+			args: []string{"./..."},
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"S/lib.go", pkg("S", "D"), nil},
+						{"M/main.go", pkg("main", "C/S"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"lib.go", pkg("D"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/S/lib.go", pkg("S", "D"), nil},
+				{"C/M/main.go", pkg("main", "C/S"), nil},
+				{"C/Godeps/_workspace/src/D/lib.go", pkg("D"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()


### PR DESCRIPTION
Stow away the helper files when trying to import the package …

There are many projects outside that have some helper binaries with a
"// +build ignore" clause and "main" package in a directory, where the
rest of files have some other package name.

In this commit we are renaming them, so they won't get picked up by
build context. After we are done, they are renamed back.

This is just a POC addressing #345.