### PR TITLE
Parse files ourselves

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,14 @@
+# v34 2015/12/08
+
+* We now use build.Context to help locate packages only and do our own parsing (via go/ast).
+* Fixes reported issues caused by v33 (Removal of `go list`):
+    * #345: Bug in godep restore
+    * #346: Fix loading a dot package
+    * #348: Godep save issue when importing lib/pq
+    * #350: undefined: build.MultiplePackageError
+    * #351: stow away helper files
+    * #353: cannot find package "appengine"
+
 # v33 2015/12/07
 
 * Replace the use of `go list`. This is a large change although all existing tests pass.

--- a/dep.go
+++ b/dep.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
@@ -54,6 +55,9 @@ func containsPathPrefix(pats []string, s string) bool {
 func uniq(a []string) []string {
 	var s string
 	var i int
+	if !sort.StringsAreSorted(a) {
+		sort.Strings(a)
+	}
 	for _, t := range a {
 		if t != s {
 			a[i] = t

--- a/dep.go
+++ b/dep.go
@@ -52,8 +52,8 @@ func containsPathPrefix(pats []string, s string) bool {
 }
 
 func uniq(a []string) []string {
-	i := 0
-	s := ""
+	var s string
+	var i int
 	for _, t := range a {
 		if t != s {
 			a[i] = t

--- a/godepfile.go
+++ b/godepfile.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 )
 
 var (
@@ -91,7 +90,6 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 	for i, p := range path {
 		path[i] = unqualify(p)
 	}
-	sort.Strings(path)
 	path = uniq(path)
 	ps, err = LoadPackages(path...)
 	if err != nil {

--- a/list.go
+++ b/list.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -92,8 +91,6 @@ func listPackage(path string) (*Package, error) {
 	var dir string
 	var lp *build.Package
 	var err error
-	deps := make(map[string]bool)
-	imports := make(map[string]bool)
 	if build.IsLocalImport(path) {
 		dir = path
 		if !filepath.IsAbs(dir) {
@@ -181,18 +178,12 @@ func listPackage(path string) (*Package, error) {
 		debugln("ip:", ip)
 		if lp == ip {
 			debugln("lp == ip")
-			imports[dp.ImportPath] = true
+			p.Imports = append(p.Imports, dp.ImportPath)
 		}
-		deps[dp.ImportPath] = true
+		p.Deps = append(p.Deps, dp.ImportPath)
 	}
-	for k := range deps {
-		p.Deps = append(p.Deps, k)
-	}
-	for k := range imports {
-		p.Imports = append(p.Imports, k)
-	}
-	sort.Strings(p.Imports)
-	sort.Strings(p.Deps)
+	p.Imports = uniq(p.Imports)
+	p.Deps = uniq(p.Deps)
 	debugln("Looking For Package:", path, "in", dir)
 	ppln(p)
 	return p, nil

--- a/list.go
+++ b/list.go
@@ -51,7 +51,7 @@ func (ds *depScanner) Continue() bool {
 
 // Add a package and imports to the depScanner. Skips already processed package/import combos
 func (ds *depScanner) Add(pkg *build.Package, imports ...string) {
-Next:
+NextImport:
 	for _, i := range imports {
 		if i == "C" {
 			i = "runtime/cgo"
@@ -60,17 +60,17 @@ Next:
 		for _, epc := range ds.processed {
 			if epc == pc {
 				debugln("ctxts epc == pc, skipping", epc, pc)
-				continue Next
+				continue NextImport
 			}
 			if pc.pkg.Dir == epc.pkg.Dir && pc.imp == epc.imp {
 				debugln("ctxts epc.pkg.Dir == pc.pkg.Dir && pc.imp == epc.imp, skipping", epc.pkg.Dir, pc.imp)
-				continue Next
+				continue NextImport
 			}
 		}
 		for _, epc := range ds.todo {
 			if epc == pc {
 				debugln("ctxts epc == pc, skipping", epc, pc)
-				continue Next
+				continue NextImport
 			}
 		}
 		debugln("Adding pc:", pc)

--- a/list.go
+++ b/list.go
@@ -114,9 +114,7 @@ func listPackage(path string) (*Package, error) {
 			lp, err = buildContext.Import(path, dir, 0)
 		}
 	}
-	if !lp.Goroot && err == nil {
-		fillPackage(lp)
-	}
+	fillPackage(lp)
 	p := &Package{
 		Dir:            lp.Dir,
 		Root:           lp.Root,
@@ -171,10 +169,8 @@ func listPackage(path string) (*Package, error) {
 			ppln(err)
 		}
 	Found:
+		fillPackage(dp)
 		ppln(dp)
-		if !dp.Goroot {
-			fillPackage(dp)
-		}
 		if dp.Goroot {
 			// Treat packages discovered to be in the GOROOT as if the package we're looking for is importing them
 			ds.Add(lp, dp.Imports...)
@@ -204,6 +200,10 @@ func listPackage(path string) (*Package, error) {
 
 // fillPackage full of info. Assumes a build.Package discovered in build.FindOnly mode
 func fillPackage(p *build.Package) error {
+
+	if p.Goroot {
+		return nil
+	}
 
 	var buildMatch = "+build "
 	var buildFieldSplit = func(r rune) bool {

--- a/list.go
+++ b/list.go
@@ -219,7 +219,7 @@ func fillPackage(p *build.Package) error {
 
 	var testImports []string
 	var imports []string
-
+NextFile:
 	for _, file := range gofiles {
 		debugln(file)
 		fset := token.NewFileSet()
@@ -239,9 +239,10 @@ func fillPackage(p *build.Package) error {
 				ct := c.Text()
 				if i := strings.Index(ct, buildMatch); i != -1 {
 					for _, b := range strings.FieldsFunc(ct[i+len(buildMatch):], buildFieldSplit) {
-						if b == "ignore" {
+						//TODO: appengine is a special case for now: https://github.com/tools/godep/issues/353
+						if b == "ignore" || b == "appengine" {
 							p.IgnoredGoFiles = append(p.IgnoredGoFiles, fname)
-							continue
+							continue NextFile
 						}
 					}
 				}

--- a/save_test.go
+++ b/save_test.go
@@ -1168,7 +1168,7 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
-		{ // build +ignore
+		{ // build +ignore: #345, #348
 			cwd: "C",
 			start: []*node{
 				{

--- a/save_test.go
+++ b/save_test.go
@@ -1223,6 +1223,39 @@ func TestSave(t *testing.T) {
 				Packages:   []string{"./..."},
 			},
 		},
+		{ // ignore `// +build appengine` as well for now: #353
+			cwd: "C",
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main", "D"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"main.go", pkg("D"), nil},
+						{"ignore.go", pkgWithTags("M", "appengine"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main", "D"), nil},
+				{"C/Godeps/_workspace/src/D/main.go", pkg("D"), nil},
+				{"C/Godeps/_workspace/src/D/ignore.go", pkgWithTags("M", "appengine"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()

--- a/save_test.go
+++ b/save_test.go
@@ -23,7 +23,7 @@ type node struct {
 }
 
 var (
-	pkgtpl = template.Must(template.New("package").Parse(`{{ if .Tags }}{{printf "// +build %s\n\n" .Tags }}{{end}}package {{.Name}}
+	pkgtpl = template.Must(template.New("package").Parse(`package {{.Name}}
 
 import (
 {{range .Imports}}	{{printf "%q" .}}
@@ -46,18 +46,12 @@ func pkg(name string, imports ...string) string {
 	return buf.String()
 }
 
+func pkgWithTags(name, tags string, imports ...string) string {
+	return "// +build " + tags + "\n\n" + pkg(name, imports...)
+}
+
 func pkgWithImpossibleTag(name string, imports ...string) string {
-	v := struct {
-		Name    string
-		Tags    string
-		Imports []string
-	}{name, impossibleTag(), imports}
-	var buf bytes.Buffer
-	err := pkgtpl.Execute(&buf, v)
-	if err != nil {
-		panic(err)
-	}
-	return buf.String()
+	return pkgWithTags(name, impossibleTag(), imports...)
 }
 
 func impossibleTag() string {

--- a/save_test.go
+++ b/save_test.go
@@ -1201,6 +1201,28 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // No buildable . #346
+			cwd:  "C",
+			args: []string{"./..."},
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"sub/main.go", pkg("main"), nil},
+						{"+git", "C", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/sub/main.go", pkg("main"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps:       []Dependency{},
+				Packages:   []string{"./..."},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()

--- a/save_test.go
+++ b/save_test.go
@@ -1168,6 +1168,39 @@ func TestSave(t *testing.T) {
 				},
 			},
 		},
+		{ // build +ignore
+			cwd: "C",
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main", "D"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"main.go", pkg("D"), nil},
+						{"ignore.go", pkgWithTags("M", "ignore"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+			},
+			want: []*node{
+				{"C/main.go", pkg("main", "D"), nil},
+				{"C/Godeps/_workspace/src/D/main.go", pkg("D"), nil},
+				{"C/Godeps/_workspace/src/D/ignore.go", pkgWithTags("M", "ignore"), nil},
+			},
+			wdep: Godeps{
+				ImportPath: "C",
+				Deps: []Dependency{
+					{ImportPath: "D", Comment: "D1"},
+				},
+			},
+		},
 	}
 
 	wd, err := os.Getwd()

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 33
+const version = 34
 
 var cmdVersion = &Command{
 	Usage: "version",


### PR DESCRIPTION
I tried to use build.Context to handle most of the grunt work, but that didn't work out that well.

So now we use it to help us find the package and then we use ast.ParseFile to parse the *.go files in a package and then fill in the rest of the build.Package

We ignore all `// +build ignore` tagged files.

Fixes #348