### PR TITLE
[WIP] Performance Regression Patch. First pass

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+# v35 2015/12/11
+
+* Fixes #356: Major performance regressions in v34
+    * Enable cpu profiling via flag on save.
+    * Cache packages by dir
+    * Don't do a full import pass on deps for packages in the GOROOT
+    * create a bit less garbage at times
+* Generalize -v & -d flags
+
 # v34 2015/12/08
 
 * We now use build.Context to help locate packages only and do our own parsing (via go/ast).

--- a/diff.go
+++ b/diff.go
@@ -9,7 +9,7 @@ import (
 )
 
 var cmdDiff = &Command{
-	Usage: "diff [-d]",
+	Name:  "diff",
 	Short: "shows the diff between current and previously saved set of dependencies",
 	Long: `
 Shows the difference, in a unified diff format, between the
@@ -19,10 +19,6 @@ previous 'go save' execution.
 If -d is given, debug output is enabled (you probably don't want this).
 `,
 	Run: runDiff,
-}
-
-func init() {
-	cmdDiff.Flag.BoolVar(&debug, "d", false, "enable debug output")
 }
 
 func runDiff(cmd *Command, args []string) {

--- a/get.go
+++ b/get.go
@@ -7,7 +7,8 @@ import (
 )
 
 var cmdGet = &Command{
-	Usage: "get [-v] [-d] [-t] [packages]",
+	Name:  "get",
+	Args:  "[-t] [packages]",
 	Short: "download and install packages with specified dependencies",
 	Long: `
 Get downloads to GOPATH the packages named by the import paths, and installs
@@ -15,10 +16,6 @@ them with the dependencies specified in their Godeps files.
 
 If any of the packages do not have Godeps files, those are installed
 as if by go get.
-
-If -v is given, verbose output is enabled.
-
-If -d is given, debug output is enabled (you probably don't want this, see -v above).
 
 If -t is given, dependencies of test files are also downloaded and installed.
 
@@ -30,8 +27,6 @@ For more about specifying packages, see 'go help packages'.
 var getT bool
 
 func init() {
-	cmdGet.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
-	cmdGet.Flag.BoolVar(&debug, "d", false, "enable debug output")
 	cmdGet.Flag.BoolVar(&getT, "t", false, "get test dependencies")
 }
 

--- a/go.go
+++ b/go.go
@@ -10,7 +10,8 @@ import (
 )
 
 var cmdGo = &Command{
-	Usage: "go command [arguments]",
+	Name:  "go",
+	Args:  "command [arguments]",
 	Short: "run the go tool with saved dependencies",
 	Long: `
 Go runs the go tool with a modified GOPATH giving access to

--- a/path.go
+++ b/path.go
@@ -6,7 +6,7 @@ import (
 )
 
 var cmdPath = &Command{
-	Usage: "path",
+	Name:  "path",
 	Short: "print GOPATH for dependency code",
 	Long: `
 Command path prints a path for use in env var GOPATH

--- a/restore.go
+++ b/restore.go
@@ -6,7 +6,7 @@ import (
 )
 
 var cmdRestore = &Command{
-	Usage: "restore [-v] [-d]",
+	Name:  "restore",
 	Short: "check out listed dependency versions in GOPATH",
 	Long: `
 Restore checks out the Godeps-specified version of each package in GOPATH.
@@ -16,11 +16,6 @@ If -v is given, verbose output is enabled.
 If -d is given, debug output is enabled (you probably don't want this, see -v above).
 `,
 	Run: runRestore,
-}
-
-func init() {
-	cmdRestore.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
-	cmdRestore.Flag.BoolVar(&debug, "d", false, "enable debug output")
 }
 
 func runRestore(cmd *Command, args []string) {

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -243,6 +243,7 @@ func TestRewrite(t *testing.T) {
 	const gopath = "godeptest"
 	defer os.RemoveAll(gopath)
 	for pos, test := range cases {
+		clearPkgCache()
 		err := os.RemoveAll(gopath)
 		if err != nil {
 			t.Fatal(err)

--- a/save.go
+++ b/save.go
@@ -93,7 +93,7 @@ func dotPackageImportPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	p, err := buildContext.ImportDir(dir, build.FindOnly)
+	p, err := build.ImportDir(dir, build.FindOnly)
 	return p.ImportPath, err
 }
 
@@ -143,6 +143,7 @@ func save(pkgs []string) error {
 		return err
 	}
 	debugln("LoadPackages", pkgs)
+	ppln(a)
 
 	err = gnew.fill(a, dip)
 	if err != nil {

--- a/save.go
+++ b/save.go
@@ -12,14 +12,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime/pprof"
 	"strings"
 
 	"github.com/tools/godep/Godeps/_workspace/src/github.com/kr/fs"
 )
 
 var cmdSave = &Command{
-	Usage: "save [-r] [-v] [-d] [-t] [packages]",
+	Name:  "save",
+	Args:  "[-r] [-t] [packages]",
 	Short: "list and copy dependencies into Godeps",
 	Long: `
 
@@ -52,10 +52,6 @@ If -r is given, import statements will be rewritten to refer
 directly to the copied source code. This is not compatible with the
 vendor experiment.
 
-If -v is given, verbose output is enabled.
-
-If -d is given, debug output is enabled (you probably don't want this, see -v).
-
 If -t is given, test files (*_test.go files + testdata directories) are
 also saved.
 
@@ -66,15 +62,12 @@ For more about specifying packages, see 'go help packages'.
 
 var (
 	saveR, saveT bool
-	cpuprofile   string
 )
 
 func init() {
-	cmdSave.Flag.BoolVar(&verbose, "v", false, "enable verbose output")
-	cmdSave.Flag.BoolVar(&debug, "d", false, "enable debug output")
 	cmdSave.Flag.BoolVar(&saveR, "r", false, "rewrite import paths")
 	cmdSave.Flag.BoolVar(&saveT, "t", false, "save test files")
-	cmdSave.Flag.StringVar(&cpuprofile, "cpuprofile", "", "")
+
 }
 
 func runSave(cmd *Command, args []string) {
@@ -98,15 +91,6 @@ func dotPackageImportPath() (string, error) {
 }
 
 func save(pkgs []string) error {
-	if cpuprofile != "" {
-		f, err := os.Create(cpuprofile)
-		if err != nil {
-			log.Fatal(err)
-		}
-		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
-	}
-
 	dip, err := dotPackageImportPath()
 	if err != nil {
 		return err

--- a/save_test.go
+++ b/save_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"go/build"
 	"io/ioutil"
 	"math"
 	"os"
@@ -63,7 +64,7 @@ func decl(name string) string {
 }
 
 func setGOPATH(paths ...string) {
-	buildContext.GOPATH = strings.Join(paths, string(os.PathListSeparator))
+	build.Default.GOPATH = strings.Join(paths, string(os.PathListSeparator))
 }
 
 func godeps(importpath string, keyval ...string) *Godeps {

--- a/save_test.go
+++ b/save_test.go
@@ -67,6 +67,10 @@ func setGOPATH(paths ...string) {
 	build.Default.GOPATH = strings.Join(paths, string(os.PathListSeparator))
 }
 
+func clearPkgCache() {
+	pkgCache = make(map[string]*build.Package)
+}
+
 func godeps(importpath string, keyval ...string) *Godeps {
 	g := &Godeps{
 		ImportPath: importpath,
@@ -1266,6 +1270,7 @@ func TestSave(t *testing.T) {
 	const scratch = "godeptest"
 	defer os.RemoveAll(scratch)
 	for pos, test := range cases {
+		clearPkgCache()
 		err = os.RemoveAll(scratch)
 		if err != nil {
 			t.Fatal(err)
@@ -1290,7 +1295,7 @@ func TestSave(t *testing.T) {
 		err = save(test.args)
 		if g := err != nil; g != test.werr {
 			if err != nil {
-				t.Log(err)
+				t.Log(pos, err)
 			}
 			t.Errorf("save err = %v want %v", g, test.werr)
 		}

--- a/update.go
+++ b/update.go
@@ -11,7 +11,8 @@ import (
 )
 
 var cmdUpdate = &Command{
-	Usage: "update [-d] [packages]",
+	Name:  "update",
+	Args:  "[packages]",
 	Short: "use different revision of selected packages",
 	Long: `
 Update changes the named dependency packages to use the
@@ -28,7 +29,6 @@ If -d is given, debug output is enabled (you probably don't want this).
 
 func init() {
 	cmdUpdate.Flag.BoolVar(&saveT, "t", false, "save test files during update")
-	cmdUpdate.Flag.BoolVar(&debug, "d", false, "enable debug output")
 }
 
 func runUpdate(cmd *Command, args []string) {

--- a/update_test.go
+++ b/update_test.go
@@ -408,6 +408,7 @@ func TestUpdate(t *testing.T) {
 	const gopath = "godeptest"
 	defer os.RemoveAll(gopath)
 	for pos, test := range cases {
+		clearPkgCache()
 		err = os.RemoveAll(gopath)
 		if err != nil {
 			t.Fatal(err)

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 34
+const version = 35
 
 var cmdVersion = &Command{
 	Name:  "version",

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 const version = 34
 
 var cmdVersion = &Command{
-	Usage: "version",
+	Name:  "version",
 	Short: "show version info",
 	Long: `
 


### PR DESCRIPTION
Locally these changes are about a 50% time reduction for a complex test
repo. There's plenty more to do though.

- Enable cpu profiling via flag on save.
- do a better compare in depScanner.Add(), comparing only the path /
  import instead of the entire struct
- remove checkGoroot as it was unused
- return if package was found to be a GOROOT package early as there's
  not much to do.
- Only create a new packageContext if we're actually adding it.
- Don't do a full scan of the dot package as we were only using it's import
  path anyway.

Fixes #356 (partially)