### PR TITLE
prevent duplicate text in 'godep help restore'

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -11,9 +11,6 @@ var cmdRestore = &Command{
 	Long: `
 Restore checks out the Godeps-specified version of each package in GOPATH.
 
-If -v is given, verbose output is enabled.
-
-If -d is given, debug output is enabled (you probably don't want this, see -v above).
 `,
 	Run: runRestore,
 }


### PR DESCRIPTION
restore.go contains a duplicate of https://github.com/tools/godep/blob/master/main.go#L124 which currently leads to the duplicated text in the restore help:
```
$ ~/go/bin/godep help restore
godep help restore
Args: godep restore [-v] [-d]

Restore checks out the Godeps-specified version of each package in GOPATH.

If -v is given, verbose output is enabled.

If -d is given, debug output is enabled (you probably don't want this, see -v above).

If -v is given, verbose output is enabled.

If -d is given, debug output is enabled (you probably don't want this, see -v).
'''