### PR TITLE
Replace `go get`, further fix up error handling/reporting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+# v38 2015/12/16
+
+* Replace `go get`, further fix up restore error handling/reporting.
+    * Fixes #186
+    * Don't bother restoring/downloading if already done.
+
 # v37 2015/12/15
 
 * Change up how download/restore works a little

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 37
+const version = 38
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
Fixes another issue reported in #186 where an entire package is missing.

Don't bother restoring/downloading if already done.
