### PR TITLE
Fix a bunch of GO15VENDOREXPERIMENT issues

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,16 @@
+# v42 2015/12/22
+
+* Fix a bunch of GO15VENDOREXPERIMENT issues
+    * Find package directories better. Previously we used build.FindOnly which didn't work the way I expected it to (any dir would work w/o error).
+    * Set the VendorExperiment bool based on go version as 1.6 defaults to on.
+    * A bunch of extra debugging for use while sanity checking myself.
+    * vendor flag for test structs.
+    * Some tests for vendor/ stuff:
+        * Basic Test
+        * Transitive
+        * Transitive, across GOPATHs + collapse vendor/ directories.
+* Should Fix #358
+
 # v41 2015/12/17
 
 * Don't rewrite packages outside of the project. This would happen if you specified

--- a/errors.go
+++ b/errors.go
@@ -8,3 +8,11 @@ var (
 	errorCopyingSourceCode   = errors.New("error copying source code")
 	errorNoPackagesUpdatable = errors.New("no packages can be updated")
 )
+
+type errPackageNotFound struct {
+	path string
+}
+
+func (e errPackageNotFound) Error() string {
+	return "Package (" + e.path + ") not found"
+}

--- a/godepfile.go
+++ b/godepfile.go
@@ -54,6 +54,8 @@ func loadDefaultGodepsFile() (Godeps, error) {
 
 // pkgs is the list of packages to read dependencies for
 func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
+	debugln("fill", destImportPath)
+	ppln(pkgs)
 	var err1 error
 	var path, testImports []string
 	for _, p := range pkgs {
@@ -87,10 +89,12 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 		path = append(path, p.ImportPath)
 		path = append(path, p.Deps...)
 	}
+	debugln("path", path)
 	for i, p := range path {
 		path[i] = unqualify(p)
 	}
 	path = uniq(path)
+	debugln("uniq, unqualify'd path", path)
 	ps, err = LoadPackages(path...)
 	if err != nil {
 		return err

--- a/pkg.go
+++ b/pkg.go
@@ -38,6 +38,7 @@ type Package struct {
 // Files with a build tag of `ignore` are skipped. Files with other build tags
 // are however processed.
 func LoadPackages(names ...string) (a []*Package, err error) {
+	debugln("LoadPackages", names)
 	if len(names) == 0 {
 		return nil, nil
 	}

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestUnqualify(t *testing.T) {
+	setGlobals(false)
 	var cases = []struct {
 		path string
 		want string
@@ -243,7 +244,7 @@ func TestRewrite(t *testing.T) {
 	const gopath = "godeptest"
 	defer os.RemoveAll(gopath)
 	for pos, test := range cases {
-		clearPkgCache()
+		setGlobals(false)
 		err := os.RemoveAll(gopath)
 		if err != nil {
 			t.Fatal(err)

--- a/save.go
+++ b/save.go
@@ -142,15 +142,19 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
-	debugln("LoadPackages", pkgs)
+	debugln("Project Packages", pkgs)
 	ppln(a)
 
 	projA := projectPackages(dp.Dir, a)
+	debugln("Filtered projectPackages")
+	ppln(projA)
+
 	err = gnew.fill(a, dp.ImportPath)
 	if err != nil {
 		return err
 	}
 	debugln("New Godeps Filled")
+	ppln(gnew)
 
 	if gnew.Deps == nil {
 		gnew.Deps = make([]Dependency, 0) // produce json [], not null
@@ -160,6 +164,7 @@ func save(pkgs []string) error {
 	if err != nil {
 		return err
 	}
+
 	if gold.isOldFile {
 		// If we are migrating from an old format file,
 		// we require that the listed version of every
@@ -186,7 +191,11 @@ func save(pkgs []string) error {
 	//   godep go list ./...
 	srcdir := filepath.FromSlash(strings.Trim(sep, "/"))
 	rem := subDeps(gold.Deps, gnew.Deps)
+	debugln("Deps to remove")
+	ppln(rem)
 	add := subDeps(gnew.Deps, gold.Deps)
+	debugln("Deps to add")
+	ppln(add)
 	err = removeSrc(srcdir, rem)
 	if err != nil {
 		return err
@@ -205,6 +214,8 @@ func save(pkgs []string) error {
 			rewritePaths = append(rewritePaths, dep.ImportPath)
 		}
 	}
+	debugln("rewritePaths")
+	ppln(rewritePaths)
 	return rewrite(projA, dp.ImportPath, rewritePaths)
 }
 

--- a/update_test.go
+++ b/update_test.go
@@ -12,12 +12,13 @@ import (
 
 func TestUpdate(t *testing.T) {
 	var cases = []struct {
-		cwd   string
-		args  []string
-		start []*node
-		want  []*node
-		wdep  Godeps
-		werr  bool
+		cwd    string
+		args   []string
+		vendor bool
+		start  []*node
+		want   []*node
+		wdep   Godeps
+		werr   bool
 	}{
 		{ // simple case, update one dependency
 			cwd:  "C",
@@ -408,7 +409,7 @@ func TestUpdate(t *testing.T) {
 	const gopath = "godeptest"
 	defer os.RemoveAll(gopath)
 	for pos, test := range cases {
-		clearPkgCache()
+		setGlobals(test.vendor)
 		err = os.RemoveAll(gopath)
 		if err != nil {
 			t.Fatal(err)

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 41
+const version = 42
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
- Find package directories better. Previously we used build.FindOnly
  which didn't work the way I expected it to (any dir would work w/o
  error).
- Set the VendorExperiment bool based on go version as 1.6 defaults to
  on.
- A bunch of extra debugging for use while sanity checking myself.
- vendor flag for test structs.
- Some tests for vendor/ stuff:
    - Basic Test
    - Transitive
    - Transitive, across GOPATHs + collapse vendor/ directories.

Should Fix #358