### PR TITLE
added driveLetterToUpper function

### DIFF
--- a/list.go
+++ b/list.go
@@ -187,8 +187,10 @@ func findDirForPath(path string, ip *build.Package) (string, error) {
 	// We need to check to see if the import exists in vendor/ folders up the hierachy of the importing package
 	if VendorExperiment && ip != nil {
 		debugln("resolving vendor posibilities:", ip.Dir, ip.Root)
-		cr := filepath.Clean(ip.Root)
-		for base := ip.Dir; base != cr; base = filepath.Dir(base) {
+		cr := driveLetterToUpper(filepath.Clean(ip.Root))
+		base := driveLetterToUpper(filepath.Clean(ip.Dir))
+
+		for ; base != cr; base = filepath.Dir(base) {
 			s := filepath.Join(base, "vendor", path)
 			debugln("Adding search dir:", s)
 			search = append(search, s)

--- a/util.go
+++ b/util.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"runtime"
 )
 
 // Runs a command in dir.
@@ -25,4 +26,21 @@ func runInWithOutput(dir, name string, args ...string) (string, error) {
 	}
 
 	return string(o), err
+}
+
+// driveLetterToUpper converts Windows path's drive letters to uppercase. This
+// is needed when comparing 2 paths with different drive letter case.
+func driveLetterToUpper(path string) string {
+	if runtime.GOOS != "windows" || path == "" {
+		return path
+	}
+
+	p := path
+
+	// If path's drive letter is lowercase, change it to uppercase.
+	if len(p) >= 2 && p[1] == ':' && 'a' <= p[0] && p[0] <= 'z' {
+		p = string(p[0]+'A'-'a') + p[1:]
+	}
+
+	return p
 }


### PR DESCRIPTION
Bug fix for: https://github.com/tools/godep/issues/383

Drive letter to uppercase code was taken from:
https://github.com/golang/go/blob/master/src/path/filepath/symlink_windows.go#L62-L68