### PR TITLE
save: add a new option for skipping packages required by test files

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -36,7 +36,7 @@ func runDiff(cmd *Command, args []string) {
 		GoVersion:  gold.GoVersion,
 	}
 
-	err = gnew.fill(dot, dot[0].ImportPath)
+	err = gnew.fill(dot, dot[0].ImportPath, true)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Current godep save tries to save packages which are required by test
related files in gopath. If test files are not required (-t isn't
passed), these packages are not needed to be stored under Godeps. This
commit lets save command not to save such packages if a new option -T
is passed.
