### PR TITLE
restore: handle a case of empty GOPATH

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -25,6 +25,11 @@ Restore checks out the Godeps-specified version of each package in GOPATH.
 // 2. Restore all deps (checkout the recorded rev)
 // 3. Attempt to load all deps as a simple consistency check
 func runRestore(cmd *Command, args []string) {
+	if len(build.Default.GOPATH) == 0 {
+		log.Println("Error restore requires GOPATH but it is empty.")
+		os.Exit(1)
+	}
+
 	var hadError bool
 	checkErr := func(s string) {
 		if hadError {


### PR DESCRIPTION
When godep restore is executed with empty GOPATH, it fails with error
message like below:

panic: runtime error: index out of range

goroutine 1 [running]:
main.download(0xc82012a000, 0x0, 0x0)
        /home/mitake/gopath/src/github.com/tools/godep/restore.go:104 +0x1cb8
main.runRestore(0xaffe00, 0xc82000a390, 0x0, 0x0)
        /home/mitake/gopath/src/github.com/tools/godep/restore.go:42 +0x3a5
main.main()
        /home/mitake/gopath/src/github.com/tools/godep/main.go:118 +0xd9f

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1696 +0x1

This commit lets the command handle such a case with a little bit
grace error message like this:
godep: error downloading dep (github.com/kr/fs): GOPATH is empty
godep: error downloading dep (github.com/kr/pretty): GOPATH is empty
godep: error downloading dep (github.com/kr/text): GOPATH is empty
godep: error downloading dep (github.com/pmezard/go-difflib/difflib): GOPATH is empty
godep: error downloading dep (golang.org/x/tools/go/vcs): GOPATH is empty
godep: Error downloading some deps. Aborting restore and check.