### PR TITLE
Added support for go development version vendoring.

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 	// VendorExperiment is the Go 1.5 vendor directory experiment flag, see
 	// https://github.com/golang/go/commit/183cc0cd41f06f83cb7a2490a499e3f9101befff
 	VendorExperiment = (majorGoVersion == "go1.5" && os.Getenv("GO15VENDOREXPERIMENT") == "1") ||
-		(majorGoVersion == "go1.6" && os.Getenv("GO15VENDOREXPERIMENT") != "0")
+		(majorGoVersion == "go1.6" && os.Getenv("GO15VENDOREXPERIMENT") != "0") ||
+		(majorGoVersion == "devel" && os.Getenv("GO15VENDOREXPERIMENT") == "1")
 
 	// sep is the signature set of path elements that
 	// precede the original path of an imported package.

--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ func main() {
 	// VendorExperiment is the Go 1.5 vendor directory experiment flag, see
 	// https://github.com/golang/go/commit/183cc0cd41f06f83cb7a2490a499e3f9101befff
 	VendorExperiment = (majorGoVersion == "go1.5" && os.Getenv("GO15VENDOREXPERIMENT") == "1") ||
-		((majorGoVersion == "go1.6" || majorGoVersion == "devel") && os.Getenv("GO15VENDOREXPERIMENT") != "0")
+		(majorGoVersion == "go1.6" && os.Getenv("GO15VENDOREXPERIMENT") != "0") ||
+		(majorGoVersion == "devel" && os.Getenv("GO15VENDOREXPERIMENT") != "0")
 
 	// sep is the signature set of path elements that
 	// precede the original path of an imported package.

--- a/main.go
+++ b/main.go
@@ -89,8 +89,7 @@ func main() {
 	// VendorExperiment is the Go 1.5 vendor directory experiment flag, see
 	// https://github.com/golang/go/commit/183cc0cd41f06f83cb7a2490a499e3f9101befff
 	VendorExperiment = (majorGoVersion == "go1.5" && os.Getenv("GO15VENDOREXPERIMENT") == "1") ||
-		(majorGoVersion == "go1.6" && os.Getenv("GO15VENDOREXPERIMENT") != "0") ||
-		(majorGoVersion == "devel" && os.Getenv("GO15VENDOREXPERIMENT") == "1")
+		((majorGoVersion == "go1.6" || majorGoVersion == "devel") && os.Getenv("GO15VENDOREXPERIMENT") != "0")
 
 	// sep is the signature set of path elements that
 	// precede the original path of an imported package.


### PR DESCRIPTION
When go is compiled from source off go tip (master) and not a tagged version, the reported
major version is 'devel' rather than the released version number.

Thus a third conditional has been added to support this case when determining if vendoring should be enabled.