### PR TITLE
Document tag behavior

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -86,10 +86,12 @@
     * #350: undefined: build.MultiplePackageError
     * #351: stow away helper files
     * #353: cannot find package "appengine"
+        * Don't process imports of `.go` files tagged with the `appengine` build tag.
 
 # v33 2015/12/07
 
 * Replace the use of `go list`. This is a large change although all existing tests pass.
+    * Don't process the imports of `.go` files with the `ignore` build tag.
 
 # v32 2015/12/02
 

--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,9 @@ command, you wrap it in one of these two ways:
 - When using a different command, set your `$GOPATH` using `godep path` as
   described below.
 
+Godep does not process the imports of `.go` files with either the `ignore` 
+or `appengine` build tags.
+
 Test files and testdata directories can be saved by adding `-t`.
 
 ## Additional Operations


### PR DESCRIPTION
Starting with v33 we started processing all go files, except those with
the `ignore` build tag. In v34 we also ignore files with the `appengine`
build tag.

Fixes #391