### PR TITLE
Fix sub dirs

### DIFF
--- a/godepfile.go
+++ b/godepfile.go
@@ -69,6 +69,7 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 	ppln(pkgs)
 	var err1 error
 	var path, testImports []string
+	dipp := []string{destImportPath}
 	for _, p := range pkgs {
 		if p.Standard {
 			log.Println("ignoring stdlib package:", p.ImportPath)
@@ -110,17 +111,16 @@ func (g *Godeps) fill(pkgs []*Package, destImportPath string) error {
 	if err != nil {
 		return err
 	}
-	seen := []string{destImportPath}
 	for _, pkg := range ps {
 		if pkg.Error.Err != "" {
 			log.Println(pkg.Error.Err)
 			err1 = errorLoadingDeps
 			continue
 		}
-		if pkg.Standard || containsPathPrefix(seen, pkg.ImportPath) {
+		if pkg.Standard || containsPathPrefix(dipp, pkg.ImportPath) {
+			debugln("standard or dest skipping", pkg.ImportPath)
 			continue
 		}
-		seen = append(seen, pkg.ImportPath)
 		vcs, reporoot, err := VCSFromDir(pkg.Dir, filepath.Join(pkg.Root, "src"))
 		if err != nil {
 			log.Println(err)

--- a/save.go
+++ b/save.go
@@ -354,6 +354,7 @@ func copySrc(dir string, deps []Dependency) error {
 	visited := make(map[string]bool)
 	ok := true
 	for _, dep := range deps {
+		debugln("copySrc for", dep.ImportPath)
 		srcdir := filepath.Join(dep.ws, "src")
 		rel, err := filepath.Rel(srcdir, dep.dir)
 		if err != nil { // this should never happen
@@ -368,6 +369,7 @@ func copySrc(dir string, deps []Dependency) error {
 
 		// copy actual dependency
 		vf := dep.vcs.listFiles(dep.dir)
+		debugln("vf", vf)
 		w := fs.Walk(dep.dir)
 		for w.Step() {
 			err = copyPkgFile(vf, dir, srcdir, w)
@@ -478,8 +480,10 @@ func copyFile(dst, src string) error {
 	}
 
 	if strings.HasSuffix(dst, ".go") {
+		debugln("Copy Without Import Comment", w, r)
 		err = copyWithoutImportComment(w, r)
 	} else {
+		debugln("Copy (plain)", w, r)
 		_, err = io.Copy(w, r)
 	}
 	err1 := w.Close()

--- a/vcs.go
+++ b/vcs.go
@@ -98,7 +98,7 @@ func (v *VCS) identify(dir string) (string, error) {
 
 func (v *VCS) root(dir string) (string, error) {
 	out, err := v.runOutput(dir, v.RootCmd)
-	return string(bytes.TrimSpace(out)), err
+	return filepath.Clean(string(bytes.TrimSpace(out))), err
 }
 
 func (v *VCS) describe(dir, rev string) string {
@@ -146,6 +146,7 @@ func (vf vcsFiles) Contains(path string) bool {
 // listFiles tracked by the VCS in the repo that contains dir, converted to absolute path.
 func (v *VCS) listFiles(dir string) vcsFiles {
 	root, err := v.root(dir)
+	debugln("vcs root", root)
 	if err != nil {
 		return nil
 	}
@@ -160,7 +161,10 @@ func (v *VCS) listFiles(dir string) vcsFiles {
 			if err != nil {
 				panic(err) // this should not happen
 			}
-			files[path] = true
+
+			if filepath.Dir(path) == dir {
+				files[path] = true
+			}
 		}
 	}
 	return files


### PR DESCRIPTION
TL;DR: We were vendoring too much, this should fix that w/o breaking
anything (tm).

While working with an internal project and a bunch of go1.6 repos I
observed `go install ./...` trying to compile stuff that is in the
vendor directory, but doesn't have all of the deps also vendored. This
means that they were being copied in incorrectly.

Upon inspection of the code I noticed that vcs files would list all
files and the sub directories and the dependency checks in fill would
skip packages based on import prefix, when (AFAICT) it should only skip
standard and the primary root package importPath.

I also discovered a few tests that appear to be faulty, or exhibit older
behaviour that I didn't even think existed.

Basically this commit makes it so that when filling godeps we include
all dependencies and when saving we don't automatically process sub
directories of packages unless those sub-directories are also packages
that are required by the dependency search.

This commit adjusts some tests which I hand validated for behavior.
Most tests though are unchanged. Also added positional identifier for
more save test errors.

More debug added for later operations of save/update.