### PR TITLE
Don't use git rev-parse --show-toplevel

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+#v57 (2016/03/07)
+
+* Don't use `git rev-parse --show-toplevel` to determine git repo roots as it resolves symlinks: https://github.com/tools/godep/pull/418
+
 # v56 (2016/02/26)
 
 * replace path comparisons with case insensitive pathEqual()

--- a/vcs.go
+++ b/vcs.go
@@ -42,7 +42,7 @@ var vcsGit = &VCS{
 	DescribeCmd: "describe --tags",
 	DiffCmd:     "diff {rev}",
 	ListCmd:     "ls-files --full-name",
-	RootCmd:     "rev-parse --show-toplevel",
+	RootCmd:     "rev-parse --show-cdup",
 
 	ExistsCmd: "cat-file -e {rev}",
 }
@@ -96,9 +96,16 @@ func (v *VCS) identify(dir string) (string, error) {
 	return string(bytes.TrimSpace(out)), err
 }
 
+func absRoot(dir, out string) string {
+	if filepath.IsAbs(out) {
+		return filepath.Clean(out)
+	}
+	return filepath.Join(dir, out)
+}
+
 func (v *VCS) root(dir string) (string, error) {
 	out, err := v.runOutput(dir, v.RootCmd)
-	return filepath.Clean(string(bytes.TrimSpace(out))), err
+	return absRoot(dir, string(bytes.TrimSpace(out))), err
 }
 
 func (v *VCS) describe(dir, rev string) string {
@@ -146,7 +153,9 @@ func (vf vcsFiles) Contains(path string) bool {
 // listFiles tracked by the VCS in the repo that contains dir, converted to absolute path.
 func (v *VCS) listFiles(dir string) vcsFiles {
 	root, err := v.root(dir)
+	debugln("vcs dir", dir)
 	debugln("vcs root", root)
+	ppln(v)
 	if err != nil {
 		return nil
 	}

--- a/version.go
+++ b/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const version = 56
+const version = 57
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
`git rev-parse --show-toplevel` resolved symlinks, so don't use it. This
has caused soooo many problems. :-(

So instead we'll use `git rev-parse --show-cdup`, which outputs relative
paths to the root or an empty string. This wrapped in an Abs() should
get us what we want.