### PR TITLE
Add godep version to Godeps.json file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -109,10 +109,11 @@ Godeps is a json file with the following structure:
 
 ```go
 type Godeps struct {
-	ImportPath string
-	GoVersion  string   // Abridged output of 'go version'.
-	Packages   []string // Arguments to godep save, if any.
-	Deps       []struct {
+	ImportPath   string
+	GoVersion    string   // Abridged output of 'go version'.
+	GodepVersion string   // Abridged output of 'godep version'
+	Packages     []string // Arguments to godep save, if any.
+	Deps         []struct {
 		ImportPath string
 		Comment    string // Description of commit, if present.
 		Rev        string // VCS-specific commit ID.

--- a/diff_test.go
+++ b/diff_test.go
@@ -1,17 +1,19 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
 
-const (
-	d1 = `--- Godeps/Godeps.json
+var (
+	d1 = fmt.Sprintf(`--- Godeps/Godeps.json
 +++ $GOPATH
-@@ -1,12 +1,12 @@
+@@ -1,13 +1,13 @@
  {
         "ImportPath": "C",
         "GoVersion": "go1.2",
+        "GodepVersion": "v%d",
         "Deps": [
                 {
                         "ImportPath": "D101",
@@ -21,14 +23,15 @@ const (
                 }
         ]
  }
-`
+`, version)
 
-	d2 = `--- Godeps/Godeps.json
+	d2 = fmt.Sprintf(`--- Godeps/Godeps.json
 +++ $GOPATH
-@@ -1,12 +1,17 @@
+@@ -1,13 +1,18 @@
  {
         "ImportPath": "C",
         "GoVersion": "go1.2",
+        "GodepVersion": "v%d",
         "Deps": [
                 {
                         "ImportPath": "D101",
@@ -42,7 +45,7 @@ const (
                 }
         ]
  }
-`
+`, version)
 )
 
 var (
@@ -74,7 +77,7 @@ func TestDiff(t *testing.T) {
 	dep2.Deps[0].Comment = "D303"
 	diff, _ = diffStr(&dep1, &dep2)
 	if !diffsEqual(strings.Fields(diff), strings.Fields(d1)) {
-		t.Errorf("Expecting diffs to be equal. Obs <%q>. Exp <%q>", diff, d1)
+		t.Errorf("Expecting diffs to be equal. Obs <%s>. Exp <%s>", diff, d1)
 	}
 
 	// Test additional packages in new Godeps

--- a/godepfile.go
+++ b/godepfile.go
@@ -17,11 +17,12 @@ var (
 // Godeps describes what a package needs to be rebuilt reproducibly.
 // It's the same information stored in file Godeps.
 type Godeps struct {
-	ImportPath string
-	GoVersion  string
-	Packages   []string `json:",omitempty"` // Arguments to save, if any.
-	Deps       []Dependency
-	isOldFile  bool
+	ImportPath   string
+	GoVersion    string
+	GodepVersion string
+	Packages     []string `json:",omitempty"` // Arguments to save, if any.
+	Deps         []Dependency
+	isOldFile    bool
 }
 
 func createGodepsFile() (*os.File, error) {
@@ -176,6 +177,7 @@ func (g *Godeps) save() (int64, error) {
 }
 
 func (g *Godeps) writeTo(w io.Writer) (int64, error) {
+	g.GodepVersion = fmt.Sprintf("v%d", version) // godep always writes its current version.
 	b, err := json.MarshalIndent(g, "", "\t")
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
As discussed in #429 this change adds the current godep version to Godeps.json when writing that file.

Closes #429