### PR TITLE
filter out vendored imports, copy vendor directories

### DIFF
--- a/save_test.go
+++ b/save_test.go
@@ -1447,13 +1447,12 @@ func TestSave(t *testing.T) {
 			want: []*node{
 				{"C/main.go", pkg("main", "D"), nil},
 				{"C/vendor/D/main.go", pkg("D", "T"), nil},
-				{"C/vendor/T/main.go", pkg("T"), nil},
+				{"C/vendor/D/vendor/T/main.go", pkg("T"), nil},
 			},
 			wdep: Godeps{
 				ImportPath: "C",
 				Deps: []Dependency{
 					{ImportPath: "D", Comment: "D1"},
-					{ImportPath: "T", Comment: "T1"},
 				},
 			},
 		},

--- a/util.go
+++ b/util.go
@@ -58,3 +58,11 @@ func pathEqual(a, b string) bool {
 	b = cleanPath(b)
 	return strings.EqualFold(a, b)
 }
+
+// pathAncestor checks if a is an ancestor of b, and
+// deals with case insensitive filesystems and other weirdness
+func pathAncestor(a, b string) bool {
+	a = cleanPath(a)
+	b = cleanPath(b)
+	return strings.HasPrefix(b, a)
+}

--- a/vcs.go
+++ b/vcs.go
@@ -171,7 +171,8 @@ func (v *VCS) listFiles(dir string) vcsFiles {
 				panic(err) // this should not happen
 			}
 
-			if pathEqual(filepath.Dir(path), dir) {
+			if pathEqual(filepath.Dir(path), dir) ||
+				pathAncestor(filepath.Join(dir, "vendor"), path) {
 				files[path] = true
 			}
 		}


### PR DESCRIPTION
This addresses #444 partially. It only filters out imports of a package PKG which are present in $PKG/vendor because only those are definitely going to be used by `go build`.

Let me describe what's expected after this PR:

Say I'm at `$GOPATH/src/github.com/donhcd` and I have two git repos `test` and `test2`:

```
$ ls test
f.go
$ cat test/f.go
package test

import _ "github.com/donhcd/test2"
$ ls test2
f.go
$ cat test2/f.go
package test2

import _ "github.com/blang/semver"
```

Then
```
$ cd test
$ godep save
$ find vendor
vendor
vendor/github.com
vendor/github.com/blang
vendor/github.com/blang/semver
vendor/github.com/blang/semver/semver.go
vendor/github.com/blang/semver/sort.go
vendor/github.com/blang/semver/README.md
vendor/github.com/blang/semver/LICENSE
vendor/github.com/blang/semver/json.go
vendor/github.com/blang/semver/sql.go
vendor/github.com/donhcd
vendor/github.com/donhcd/test2
vendor/github.com/donhcd/test2/f.go
$ rm -r vendor Godeps # cleanup
```
which is the same behavior you would find in godep master.

However, my PR introduces new behavior if you follow this workflow:
```
$ cd ../test2
$ godep save
$ find vendor
vendor
vendor/github.com
vendor/github.com/blang
vendor/github.com/blang/semver
vendor/github.com/blang/semver/semver.go
vendor/github.com/blang/semver/sort.go
vendor/github.com/blang/semver/README.md
vendor/github.com/blang/semver/LICENSE
vendor/github.com/blang/semver/json.go
vendor/github.com/blang/semver/sql.go
$ cd -
$ godep save
$ find vendor
vendor
vendor/github.com
vendor/github.com/donhcd
vendor/github.com/donhcd/test2
vendor/github.com/donhcd/test2/f.go
vendor/github.com/donhcd/test2/vendor
vendor/github.com/donhcd/test2/vendor/github.com
vendor/github.com/donhcd/test2/vendor/github.com/blang
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/semver.go
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/sort.go
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/README.md
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/LICENSE
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/json.go
vendor/github.com/donhcd/test2/vendor/github.com/blang/semver/sql.go
```

In master, this would result in output identical to the first example, which causes problems if you have different dependencies using incompatible versions of `semver`.