### PR TITLE
Handle go version tags

### DIFF
--- a/match_test.go
+++ b/match_test.go
@@ -61,3 +61,22 @@ func TestSubPath(t *testing.T) {
 		}
 	}
 }
+
+func TestIsSameOrNewer(t *testing.T) {
+	cases := []struct {
+		base  string
+		check string
+		want  bool
+	}{
+		{`go1.6`, `go1.6`, true},
+		{`go1.5`, `go1.6`, true},
+		{`go1.7`, `go1.6`, false},
+	}
+
+	for _, test := range cases {
+		ok := isSameOrNewer(test.base, test.check)
+		if ok != test.want {
+			t.Errorf("isSameOrNewer(%s,%s) = %v want %v", test.base, test.check, ok, test.want)
+		}
+	}
+}

--- a/save.go
+++ b/save.go
@@ -104,6 +104,7 @@ func projectPackages(dDir string, a []*Package) []*Package {
 }
 
 func save(pkgs []string) error {
+	var err error
 	dp, err := dotPackage()
 	if err != nil {
 		return err
@@ -127,6 +128,14 @@ func save(pkgs []string) error {
 	}
 
 	printVersionWarnings(gold.GoVersion)
+	if len(gold.GoVersion) == 0 {
+		gold.GoVersion = majorGoVersion
+	} else {
+		majorGoVersion, err = trimGoVersion(gold.GoVersion)
+		if err != nil {
+			log.Fatalf("Unable to determine go major version from value specified in %s: %s\n", gold.file(), gold.GoVersion)
+		}
+	}
 
 	gnew := &Godeps{
 		ImportPath: dp.ImportPath,

--- a/save_test.go
+++ b/save_test.go
@@ -29,7 +29,7 @@ var (
 import (
 {{range .Imports}}	{{printf "%q" .}}
 {{end}})
-`))
+`)) // `
 )
 
 func pkg(name string, imports ...string) string {

--- a/version.go
+++ b/version.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"runtime"
+	"strconv"
+	"strings"
 )
 
 const version = 60
@@ -23,4 +26,35 @@ func versionString() string {
 
 func runVersion(cmd *Command, args []string) {
 	fmt.Printf("%s\n", versionString())
+}
+
+func GoVersionFields(c rune) bool {
+	return c == 'g' || c == 'o' || c == '.'
+}
+
+// isSameOrNewer go version (goA.B)
+// go1.6 >= go1.6 == true
+// go1.5 >= go1.6 == false
+func isSameOrNewer(base, check string) bool {
+	if base == check {
+		return true
+	}
+	bp := strings.FieldsFunc(base, GoVersionFields)
+	cp := strings.FieldsFunc(check, GoVersionFields)
+	if len(bp) < 2 || len(cp) < 2 {
+		log.Fatalf("Error comparing %s to %s\n", base, check)
+	}
+	if bp[0] == cp[0] { // We only have go version 1 right now
+		bm, err := strconv.Atoi(bp[1])
+		// These errors are unlikely and there is nothing nice to do here anyway
+		if err != nil {
+			panic(err)
+		}
+		cm, err := strconv.Atoi(cp[1])
+		if err != nil {
+			panic(err)
+		}
+		return cm >= bm
+	}
+	return false
 }


### PR DESCRIPTION
Fixes #448

Obey the go tool's definition of how the go versions build tags work for
the purposes of dependency scanning.

Don't use the current go version, but the recorded go version in
Godeps.json.

FIXME: We still copy the files. This is sub optimal, but probably fine
in the 80% case where people are using the version of go they have
specified in the Godeps.json file. Longer term we need to obey the
gofiles / ignore lists from the package list.

IMO, Supersedes #449 