### PR TITLE
handle detached git on restore

### DIFF
--- a/restore.go
+++ b/restore.go
@@ -146,6 +146,22 @@ func download(dep *Dependency) error {
 
 	if !dep.vcs.exists(dep.root, dep.Rev) {
 		debugln("Updating existing", dep.root)
+		if dep.vcs.vcs.Name == "Git" {
+			detached, err := gitDetached(dep.root)
+			if err != nil {
+				return err
+			}
+			if detached {
+				db, err := gitDefaultBranch(dep.root)
+				if err != nil {
+					return err
+				}
+				if err := gitCheckout(dep.root, db); err != nil {
+					return err
+				}
+			}
+		}
+
 		dep.vcs.vcs.Download(dep.root)
 		downloaded[rr.Repo] = true
 	}


### PR DESCRIPTION
If the git repo is detached, we need to determine the default remote
branch before attempting to donwload (can't pull into a repo in detached
state).

This attempts to use "git remote show origin" to have the origin tell us
what the default branch is.

PS: this may not work with old (~3 year old git servers).