### PR TITLE
Handle missing deps a little better

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+#v67 (2016/06/13)
+
+* Attempt to handle missing deps a little better.
+
 #v66 (2016/06/10)
 
 * Use `git remote show origin` to find the default branch when restoring a git based package repository that is in detached head state

--- a/dep.go
+++ b/dep.go
@@ -22,6 +22,7 @@ type Dependency struct {
 	// used by command update
 	matched bool // selected for update by command line
 	pkg     *Package
+	missing bool // packages is missing
 
 	// used by command go
 	vcs *VCS

--- a/godepfile.go
+++ b/godepfile.go
@@ -205,3 +205,20 @@ func (g *Godeps) addOrUpdateDeps(deps []Dependency) {
 		g.Deps = append(g.Deps, d)
 	}
 }
+
+func (g *Godeps) removeDeps(deps []Dependency) {
+	var f []Dependency
+	for i := range g.Deps {
+		var found bool
+		for _, d := range deps {
+			if g.Deps[i].ImportPath == d.ImportPath {
+				found = true
+				break
+			}
+		}
+		if !found {
+			f = append(f, g.Deps[i])
+		}
+	}
+	g.Deps = f
+}

--- a/save_test.go
+++ b/save_test.go
@@ -1602,6 +1602,8 @@ func makeTree(t *testing.T, tree *node, altpath string) (gopath string) {
 			os.Symlink(target, path)
 		case n.entries == nil && body == "(absent)":
 			panic("is this gonna be forever")
+		case n.entries == nil && body == "(rm)":
+			os.RemoveAll(path)
 		case n.entries == nil:
 			os.MkdirAll(filepath.Dir(path), 0770)
 			err := ioutil.WriteFile(path, []byte(body), 0660)

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const version = 66
+const version = 67
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
I added 2 tests.

The first one covers the case where we're updating a
package/... that has removed some dependencies.

The second one covers the case where we're update a package, and
another, non transitive package is missing from $GOPATH.

I'm not sure this covers everything. I need to re-read the other update
tests (but ATM they pass).