### PR TITLE
Preserve permissions when copying

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+#v71 (2016/05/24)
+
+* Preserve permissions on copied files.
+
 #v70 (2016/05/20)
 
 * Fix the May changelog dates

--- a/save.go
+++ b/save.go
@@ -479,6 +479,11 @@ func copyFile(dst, src string) error {
 		return os.Symlink(linkDst, dst)
 	}
 
+	si, err := stat(src)
+	if err != nil {
+		return err
+	}
+
 	r, err := os.Open(src)
 	if err != nil {
 		return err
@@ -487,6 +492,9 @@ func copyFile(dst, src string) error {
 
 	w, err := os.Create(dst)
 	if err != nil {
+		return err
+	}
+	if err := w.Chmod(si.Mode()); err != nil {
 		return err
 	}
 

--- a/version.go
+++ b/version.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const version = 70
+const version = 71
 
 var cmdVersion = &Command{
 	Name:  "version",


### PR DESCRIPTION
Set the file perimissions based on the permissions of the source file.
Particularly useful for copying the x bit

Fixes #404