### PR TITLE
Use os.Chmod instead of file.Chmod for compatibility with Windows

### DIFF
--- a/save.go
+++ b/save.go
@@ -494,7 +494,7 @@ func copyFile(dst, src string) error {
 	if err != nil {
 		return err
 	}
-	if err := w.Chmod(si.Mode()); err != nil {
+	if err := os.Chmod(dst, si.Mode()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Address #481 by using os.Chmod instead of file.Chmod.