### PR TITLE
[RFC] godep list

### DIFF
--- a/listCmd.go
+++ b/listCmd.go
@@ -1,0 +1,82 @@
+package main
+
+var cmdList = &Command{
+	Name:  "list",
+	Args:  "",
+	Short: "list dependencies and their state",
+	Long: `
+
+-goroot: Include dependencies located in $GOROOT
+
+Package names surrounded by "()" are main packages.
+
+/Users/emuller/go/src/github.com/heroku/log-shuttle
+    Local
+        github.com/heroku/log-shuttle
+        (github.com/heroku/log-shuttle/cmd/main/log-shuttle)
+    Godeps/_workspace/src
+        X
+        Y
+        Z
+    vendor/
+        github.com/heroku/rollrus
+        (github.com/mattes/migrate)
+    $GOPATH
+        /home/foo/go/src
+            github.com/heroku/slog
+        /home/foo/go2/src
+            D
+    $GOROOT
+        /usr/local/go/src
+            net
+            foo
+            bar
+    MISSING
+        github.com/foozle/bazzle
+
+-json: Output in JSON
+
+{
+    "Location": "/Users/emuller/go/src/github.com/heroku/log-shuttle",
+    "Local" : [
+        "github.com/heroku/log-shuttle",
+        "(github.com/heroku/log-shuttle/cmd/main/log-shuttle)"
+    ],
+    "Godeps/_workspace/src":[
+        "X", "Y", "Z"
+        ],
+    "vendor": [
+        "github.com/heroku/rollrus",
+        "(github.com/mattes/migrate)"
+    ],
+    "$GOPATH": {
+        "/home/foo/go/src": [
+          "github.com/heroku/slog"
+        ],
+        "/home/foo/go2/src": [
+            "D"
+        ]
+    },
+    "$GOROOT": {
+        "/usr/local/go/src": [
+            "net",
+            "foo",
+            "bar"
+        ]
+    },
+    "MISSING": [
+        "github.com/foozle/bazzle"
+    ]
+}
+
+
+
+For more about specifying packages, see 'go help packages'.
+`,
+	Run:          runList,
+	OnlyInGOPATH: true,
+}
+
+func runList(cmd *Command, args []string) {
+
+}

--- a/listCmd_test.go
+++ b/listCmd_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestListCmd(t *testing.T) {
+	var cases = []struct {
+		cwd      string
+		args     []string
+		flagR    bool
+		flagT    bool
+		vendor   bool
+		start    []*node
+		altstart []*node
+		want     string
+		werr     bool
+	}{
+		{ // 0 - simple case, one dependency
+			cwd:    "C",
+			vendor: true,
+			start: []*node{
+				{
+					"C",
+					"",
+					[]*node{
+						{"main.go", pkg("main", "D"), nil},
+						{"+git", "", nil},
+					},
+				},
+				{
+					"D",
+					"",
+					[]*node{
+						{"main.go", pkg("D"), nil},
+						{"+git", "D1", nil},
+					},
+				},
+			},
+			want: ``,
+		},
+	}
+
+	for range cases {
+
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func (c *Command) UsageExit() {
 // The order here is the order in which they are printed
 // by 'godep help'.
 var commands = []*Command{
+	cmdList,
 	cmdSave,
 	cmdGo,
 	cmdGet,


### PR DESCRIPTION
`godep list` should output what it thinks the state of packages are. This is mostly where is finds packages, so break it down by where a package is found. Packages that are `main` packages are surrounded by "()".

Proposed output for a list command:

``` console
$ godep list -goroot
/Users/emuller/go/src/github.com/heroku/log-shuttle
    Local
        github.com/heroku/log-shuttle
        (github.com/heroku/log-shuttle/cmd/main/log-shuttle)
    Godeps/_workspace/src
        X
        Y
        Z
    vendor/
        github.com/heroku/rollrus
        (github.com/mattes/migrate)
    $GOPATH
        /home/foo/go/src
            github.com/heroku/slog
        /home/foo/go2/src
            D
    $GOROOT
        /usr/local/go/src
            net
            foo
            bar
    MISSING
        github.com/foozle/bazzle
```

``` console
$ godep list -json -goroot
{
    "Location": "/Users/emuller/go/src/github.com/heroku/log-shuttle",
    "Local" : [
        "github.com/heroku/log-shuttle",
        "(github.com/heroku/log-shuttle/cmd/main/log-shuttle)"
    ],
    "Godeps/_workspace/src":[
        "X", "Y", "Z"
        ],
    "vendor": [
        "github.com/heroku/rollrus",
        "(github.com/mattes/migrate)"
    ],
    "$GOPATH": {
        "/home/foo/go/src": [
          "github.com/heroku/slog"
        ],
        "/home/foo/go2/src": [
            "D"
        ]
    },
    "$GOROOT": {
        "/usr/local/go/src": [
            "net",
            "foo",
            "bar"
        ]
    },
    "MISSING": [
        "github.com/foozle/bazzle"
    ]
}
```

Some things to consider, that currently aren't included: How should version information be relayed? In the txt output an `@v1` or something could be appended/prepended to the line, but for JSON the structure would likely need to change.
