### PR TITLE
Add foreach command to run a shell command in each dependency's directory

### DIFF
--- a/foreach.go
+++ b/foreach.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+)
+
+var cmdForeach = &Command{
+	Name:         "foreach",
+	Short:        "run a command in each dependency's path",
+	Run:          runForeach,
+	OnlyInGOPATH: true,
+}
+
+func runForeach(cmd *Command, args []string) {
+	g, err := loadDefaultGodepsFile()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if args == nil || len(args) < 1 {
+		log.Fatalln("Must provide a command to foreach")
+	}
+
+	for _, dep := range g.Deps {
+		c := exec.Command(args[0], args[1:]...)
+		c.Dir = getRoot(dep.root, dep.ImportPath)
+
+		fmt.Fprintf(os.Stderr, "\n%s:\n", dep.ImportPath)
+		out, err := c.StdoutPipe()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		serr, err := c.StderrPipe()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		go io.Copy(os.Stdout, out)
+		go io.Copy(os.Stderr, serr)
+
+		err = c.Run()
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}

--- a/foreach.go
+++ b/foreach.go
@@ -9,8 +9,14 @@ import (
 )
 
 var cmdForeach = &Command{
-	Name:         "foreach",
-	Short:        "run a command in each dependency's path",
+	Name:  "foreach",
+	Short: "run a command in each dependency's path",
+	Long: `
+Foreach runs the provided command for each dependency path in GOPATH. This can
+be useful for checking out the master branch after running "godep restore" to
+avoid breaking "go get -u".
+
+`,
 	Run:          runForeach,
 	OnlyInGOPATH: true,
 }

--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ var commands = []*Command{
 	cmdGet,
 	cmdPath,
 	cmdRestore,
+	cmdForeach,
 	cmdUpdate,
 	cmdDiff,
 	cmdVersion,

--- a/restore.go
+++ b/restore.go
@@ -25,6 +25,13 @@ https://github.com/golang/go/commit/42206598671a44111c8f726ad33dc7b265bdf669.
 	OnlyInGOPATH: true,
 }
 
+func getRoot(root, path string) string {
+	if root == "" {
+		return filepath.Join(filepath.SplitList(build.Default.GOPATH)[0], "src", path)
+	}
+	return root
+}
+
 // Three phases:
 // 1. Download all deps
 // 2. Restore all deps (checkout the recorded rev)
@@ -104,15 +111,12 @@ func download(dep *Dependency) error {
 			continue
 		}
 		if fi.IsDir() {
-			dep.root = t
+			// If none found, just pick the first GOPATH entry (AFAICT that's what go get does)
+			dep.root = getRoot(t, rr.Root)
 			break
 		}
 	}
 
-	// If none found, just pick the first GOPATH entry (AFAICT that's what go get does)
-	if dep.root == "" {
-		dep.root = filepath.Join(filepath.SplitList(build.Default.GOPATH)[0], "src", rr.Root)
-	}
 	ppln("dep", dep)
 
 	if downloaded[rr.Repo] {


### PR DESCRIPTION
I think this gives a very simple solution to #453 of simply running `godep foreach git checkout master` to fix any inconsistencies caused by `godep restore`. I'm sure it could be useful in other ways as well, and matches up well with the `git submodule foreach` paradigm.

I'm sure there are other enhancements that could be made to this, so I'd be glad to go through the work to get it up to the necessary quality for inclusion. Let me know what I can do. :smile: 