### PR TITLE
Update the dependencies in the vendor folder from my private repository

### DIFF
--- a/update.go
+++ b/update.go
@@ -221,7 +221,7 @@ func LoadVCSAndUpdate(deps []Dependency) ([]Dependency, []Dependency, error) {
 	repoMask := make(map[string]bool)
 	for i := range deps {
 		if !deps[i].matched {
-			repoMask[deps[i].root] = true
+			repoMask[deps[i].ImportPath] = true
 		}
 	}
 
@@ -254,7 +254,7 @@ func LoadVCSAndUpdate(deps []Dependency) ([]Dependency, []Dependency, error) {
 
 	var toUpdate, toRemove []Dependency
 	for _, d := range deps {
-		if !d.matched || repoMask[d.root] {
+		if !d.matched || repoMask[d.ImportPath] {
 			continue
 		}
 		if d.missing {


### PR DESCRIPTION
When I do changes in some library that is in other project but into my private repository and I want pass those changes to the same library that I have into the vendor folder, I could not do it.

I have made the following changes in the LoadVCSAndUpdate function, for it can update individually our library that we have changed in the GOPATH and pass that change to the vendor folder of our main project folder:

I changed the index in repoMask of deps [i] .root to deps [i] .ImportPath, since it was overwriting with other dependencies that we are importing in our main project that are within the same repository.

In the loop that add a dependency to "Update" slice, I modified for to get the entries for repoMask map obtained by the new index d.ImportPath.

Note: The root contains the "import repo path to root" and the libraries we have within a project is always the same. The ImportPath contains the import that we made in our main project.

Example:
This is an example of what you want to do.

```
/GOPATH
    /github.com
    /my_repo
        /mainproject
            main.go
            /internal_library
                ...
            /Godeps
            /vendor
            ...
        /library1
            ...
        /library2
            ...
```
- main.go import the library1 and library2 libraries. . The command "godep save", it creates  Godeps and folder vendor correctly.
- Change some file in the library1 library that is inside the GOPATH.
- cd /GOPATH/my_repo/mainproject
- The command "godep update library1", it not update the library1 in the vendor folder and Godeps.json.

With this change the "godep update library1" work.
