### PR TITLE
Consider "AUTHORS" and "CONTRIBUTORS" legal files

### DIFF
--- a/license.go
+++ b/license.go
@@ -13,6 +13,8 @@ var LicenseFilePrefix = []string{
 	"unlicense",
 	"copyright",
 	"copyleft",
+	"authors",
+	"contributors",
 }
 
 // LegalFileSubstring are substrings that indicate the file is likely


### PR DESCRIPTION
Some packages, such as github.com/tchap/go-patricia, have an AUTHORS
file to list the names of the copyright holders.

Some packages include a CONTRIBUTORS file that licenses refer to. For
example golang.org/x/sys/LICENSE and golang.org/x/sys/CONTRIBUTORS