### PR TITLE
add support for go1.8

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func determineVendor(v string) bool {
 	ev := (v == "go1.5" && go15ve == "1") ||
 		(v == "go1.6" && go15ve != "0") ||
 		(v == "go1.7") ||
+		(v == "go1.8") ||
 		(strings.HasPrefix(v, "devel") && go15ve != "0")
 
 	ws := filepath.Join("Godeps", "_workspace")


### PR DESCRIPTION
In order to test go 1.8 as soon as possible we should be able to also use godep already.

I could also submit a more advanced fix (which would also cover go version 1.9, 1.10, etc.) but I am not sure if that is wanted?