### PR TITLE
Don't include quotes around hg revisions

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -51,7 +51,7 @@ var vcsGit = &VCS{
 var vcsHg = &VCS{
 	vcs: vcs.ByCmd("hg"),
 
-	IdentifyCmd: "parents --template '{node}'",
+	IdentifyCmd: "parents --template {node}",
 	DescribeCmd: "log -r . --template {latesttag}-{latesttagdistance}",
 	DiffCmd:     "diff -r {rev}",
 	ListCmd:     "status --all --no-status",


### PR DESCRIPTION
Prior to this change, the saved revision in a Godeps.json would include
the single quotes around it from the template.

An example of what the mistake this fixes looks like in the wild: https://github.com/kubernetes/kubernetes/blob/v1.5.1/Godeps/Godeps.json#L16-L20