### PR TITLE
Refer to golang/dep in the Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,14 @@ but you can use it on any project that works with Go 1 or newer.
 
 Please check the [FAQ](FAQ.md) if you have a question.
 
+## Golang Dep
+
+The Go community now has the [dep](https://github.com/golang/dep) project to
+manage dependencies. Please consider trying to migrate from Godep to dep. If there
+is an issue preventing you from migrating please file an issue with dep so the
+problem can be corrected. Godep will continue to be supported for some time but
+is considered to be in a state of support rather than active feature development.
+
 ## Install
 
 ```console


### PR DESCRIPTION
Suggest users to use golang dep that should become the dependency
management tool for go.

The text has been adapted from Glide's readme

solves #546 

Signed-off-by: Thibault Jamet <tjamet@users.noreply.github.com>