### PR TITLE
Use a fixed abbreviation size in `git describe` output

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -40,7 +40,7 @@ var vcsGit = &VCS{
 	vcs: vcs.ByCmd("git"),
 
 	IdentifyCmd: "rev-parse HEAD",
-	DescribeCmd: "describe --tags",
+	DescribeCmd: "describe --tags --abbrev=14",
 	DiffCmd:     "diff {rev}",
 	ListCmd:     "ls-files --full-name",
 	RootCmd:     "rev-parse --show-cdup",


### PR DESCRIPTION
Currently, this setting depends on whatever the user of `godep` has in their `git config --get core.abbrev`, if it is set.

Even when it is not set, the number of characters used in the shortened git commit will depend on whether there are collisions for that prefix on the local repository (which in large part depends on how much activity exists there.)

As a result, when multiple users are maintaining Godeps/ for a single project, many spurious changes to Godeps/Godeps.json are generated due to the lack of stability in the length of the abbreviated commit in output of `git describe`.

Let's fix this by enforcing a reasonable abbreviation length in godep's use of `git describe`. 14 characters is very unlikely to result in collisions for prefixes.

**NOTE**: I understand `godep` is mostly deprecated at this point, but it's still in wide use at Kubernetes.

I tried looking for solutions that didn't necessarily involve patching `godep` itself (such as setting environment variables such as `GIT_CONFIG`) but none of them really worked...

I thought this was simple enough and straightforward that it might be reasonable to accept it?

Thanks!
Filipe
